### PR TITLE
Keep fnl blinding blind

### DIFF
--- a/scripts/main/apply_blinding_main_fromfile_fcomp.py
+++ b/scripts/main/apply_blinding_main_fromfile_fcomp.py
@@ -464,7 +464,9 @@ if args.fnlblind == 'y':
 
         # overwrite the data!
         if root:
+            fnl_blind_weights = new_data_weights / data['WEIGHT']
             data['WEIGHT'] = new_data_weights
+            data['WEIGHT_COMP'] = data['WEIGHT_COMP'] * fnl_blind_weights
             common.write_LSS(data, data_fn)
 
 if root:


### PR DESCRIPTION
actually, one can easily compute the power spectrum without the fnl_blinding and so break the blind procedure ...

