### PR TITLE
xirunpc: allow the post-recon filenames from desipipe

### DIFF
--- a/py/LSS/cosmodesi_io_tools.py
+++ b/py/LSS/cosmodesi_io_tools.py
@@ -128,10 +128,10 @@ def catalog_fn(tracer='ELG', region='', ctype='clustering', name='data', ran_sw=
     if name == 'randoms' and tracer == 'LRG_main' and ctype == 'full':
         tracer = 'LRG'
     if region: region = '_' + region
+    #recon_dir = kwargs['recon_dir']
+    if recon_dir != 'n':
+        tracer = recon_dir+'/'+tracer
     if rec_type:
-        #recon_dir = kwargs['recon_dir']
-        if recon_dir != 'n':
-            tracer = recon_dir+'/'+tracer
         dat_or_ran = '{}.{}'.format(rec_type, dat_or_ran)
     if name == 'data':
         return os.path.join(cat_dir, '{}{}_{}.{}.fits'.format(tracer, region, ctype, dat_or_ran))

--- a/scripts/xirunpc.py
+++ b/scripts/xirunpc.py
@@ -422,7 +422,7 @@ def compute_correlation_function(corr_type, edges, distance, nthreads=8, gpu=Fal
     catalog_kwargs = kwargs.copy()
     catalog_kwargs['weight_type'] = weight_type
     #catalog_kwargs['recon_dir'] = recon_dir
-    with_shifted = rec_type is not None
+    with_shifted = rec_type is not None or recon_dir != "n"
 
     if 'angular' in weight_type and wang is None:
         wang = compute_angular_weights(nthreads=nthreads, gpu=gpu, dtype=dtype, weight_type=weight_type, tracer=tracer, tracer2=tracer2, mpicomm=mpicomm, mpiroot=mpiroot, **kwargs)

--- a/scripts/xirunpc.py
+++ b/scripts/xirunpc.py
@@ -597,7 +597,7 @@ if __name__ == '__main__':
     parser.add_argument('--use_arrays', help = 'use pre-stored arrays rather than reading from memory again', default = 'n')
     parser.add_argument('--write_arrays', help = 'save the pre-stored arrays', default = 'n')
     #only relevant for reconstruction
-    parser.add_argument('--rec_type', help='reconstruction algorithm + reconstruction convention', choices=['IFTPrecsym', 'IFTPreciso','IFTrecsym', 'IFTreciso', 'MGrecsym', 'MGreciso'], type=str, default=None)
+    parser.add_argument('--rec_type', help='reconstruction algorithm + reconstruction convention, but only if included in the catalog filename between dots, otherwise leave blank', choices=['IFTPrecsym', 'IFTPreciso','IFTrecsym', 'IFTreciso', 'MGrecsym', 'MGreciso'], type=str, default=None)
     parser.add_argument('--recon_dir', help='if recon catalogs are in a subdirectory, put that here', type=str, default='n')
 
     parser.add_argument('--rpcut', help='apply this rp-cut', type=float, default=None)


### PR DESCRIPTION
The new `desipipe` filenames lack the `{rec_type}.` part, I allowed to skip it while including the `recon_dir`.