### PR TITLE
Qsocat qn columns

### DIFF
--- a/py/LSS/qso_cat_utils.py
+++ b/py/LSS/qso_cat_utils.py
@@ -410,7 +410,8 @@ def qso_catalog_maker(redrock, mgii, qn, use_old_extname_for_redrock=False, use_
     # I do this here to match the same behavior than previously !
     QSO_cat['IS_QSO_QN_NEW_RR'] &= QSO_cat['IS_QSO_QN_099']
     log.info('Selection with SPECTYPE.')
-
+    QSO_cat.loc[is_QSO & (QSO_cat['SPECTYPE'] == 'QSO'), 'QSO_MASKBITS'] += 2**1
+    log.info('Selection with MgII.')
     QSO_cat.loc[is_QSO & QSO_cat['IS_QSO_MGII'], 'QSO_MASKBITS'] += 2**2
     log.info('Selection with QN (add new z from Redrock with QN prior where it is relevant).')
     QSO_cat.loc[is_QSO & QSO_cat['IS_QSO_QN_099'], 'QSO_MASKBITS'] += 2**3


### PR DESCRIPTION
This PR updates the ZWARN column for QN-identified QSOs with new Redrock redshifts. Previously only the Z, ZERR columns were updated for these objects, meaning the ZWARN value was set from the initial Redrock run.

This PR follows desispec [#2407](https://github.com/desihub/desispec/pull/2407), which extended the list of saved attributes from the QN informed redrock rerun to include ZWARN. Backward compatibility is maintained with the update_qn_zwarn argument.

I verified `update_qn_zwarn=False` and `update_qn_zwarn=True` give identical catalogs aside from the zwarn column in ~1%. Comparing to the existing healpix Loa catalog, I found changes for Z, ZERR, ZWARN. The Z/ZERR changes are limited to 1.4<z<1.6 where I believe we expect some shuffling from updates to the QN afterburner script.

Test catalog with default  `update_qn_zwarn=True`  here: `/global/cfs/cdirs/desi/users/abrodze/test_qsocat/QSO_cat_loa_main_dark_healpix_test.fits`

@dylanagreen please check that things look right.