### PR TITLE
Setting update_qn_zwarn=False for daily QSO catalog compatibility

### DIFF
--- a/py/LSS/main/cattools.py
+++ b/py/LSS/main/cattools.py
@@ -850,7 +850,7 @@ def combQSOdata(tile,zdate,tdate,coaddir='/global/cfs/cdirs/desi/spectro/redux/d
         qn = coaddir+str(tile)+'/'+zdate+'/'+'qso_qn'+'-'+str(specs[i])+'-'+str(tile)+'-thru'+tdate+'.fits'
         old_extname_redrock = True if zhdu == 'ZBEST' else False
         old_extname_for_qn = False #if int(tdate) >= 20220118 else True
-        qso_cati = Table.from_pandas(qso_catalog_maker(rr, mgii, qn, old_extname_redrock, old_extname_for_qn))
+        qso_cati = Table.from_pandas(qso_catalog_maker(rr, mgii, qn, old_extname_redrock, old_extname_for_qn, update_qn_zwarn = False))
         #qso_cati = Table(qso_catalog_maker(rr, mgii, qn, old_extname_redrock, old_extname_for_qn))
         qsocats.append(qso_cati)
         #if i == 0:


### PR DESCRIPTION
Minor change to the `combQSOdata` function in `cattools.py` setting `update_qn_zwarn` = False in the `qso_catalog_maker` in order to ensure the daily QSO catalog can be generated. 

Please confirm that this change will not affect any other tools that use this function before merging.