### PR TITLE
Removed inflate_ledger call when survey is main, added single_action option to loop_alt_ledger

### DIFF
--- a/py/LSS/SV3/altmtltools.py
+++ b/py/LSS/SV3/altmtltools.py
@@ -13,7 +13,7 @@
 #
 
 import collections.abc
-from time import time
+from time import time 
 import astropy
 import astropy.io
 import astropy.io.fits as pf
@@ -1310,7 +1310,7 @@ def loop_alt_ledger(obscon, survey='sv3', zcatdir=None, mtldir=None,
                     getosubp = False, quickRestart = False, redoFA = False,
                     multiproc = False, nproc = None, testDoubleDate = False, 
                     changeFiberOpt = None, targets = None, mock = False,
-                    debug = False, verbose = False, reproducing = False):
+                    debug = False, verbose = False, reproducing = False, single_action = False):
     """Execute full MTL loop, including reading files, updating ledgers.
 
     Parameters
@@ -1357,6 +1357,8 @@ def loop_alt_ledger(obscon, survey='sv3', zcatdir=None, mtldir=None,
     nproc : :class:`int`, optional, defaults to None
         If multiproc is ``True`` this must be specified. Integer determines 
         directory of alternate MTLs to update.
+    single_action : :class:`bool`, optional, defaults to False
+        If ``True`` then run a single dateloop iteration. Used in profiling.
 
     Returns
     -------
@@ -1463,15 +1465,21 @@ def loop_alt_ledger(obscon, survey='sv3', zcatdir=None, mtldir=None,
 
         #for ots,famtlt,reprocFlag in datepairs:
         #while int(today) <= int(endDate):
+
+        #restricting to a single action for profiling use, is this overlapping with some other option? multiproc?
+        if single_action:
+            actionList = actionList[:1]
+        
         for action in actionList:
 
             if action['ACTIONTYPE'] == 'fa':
-
                 OrigFAs, AltFAs, AltFAs2, TSs, fadates, tiles = do_fiberassignment(altmtldir, [action], survey = survey, obscon = obscon ,verbose = verbose, debug = debug, getosubp = getosubp, redoFA = redoFA, mock = mock, reproducing = reproducing)
                 assert(len(OrigFAs))
                 A2RMap, R2AMap = make_fibermaps(altmtldir, OrigFAs, AltFAs, AltFAs2, TSs, fadates, tiles, changeFiberOpt = changeFiberOpt, verbose = verbose, debug = debug, survey = survey , obscon = obscon, getosubp = getosubp, redoFA = redoFA )
+                
             elif action['ACTIONTYPE'] == 'update':
                 althpdirname, altmtltilefn, ztilefn, tiles = update_alt_ledger(altmtldir,althpdirname, altmtltilefn, action, survey = survey, obscon = obscon ,getosubp = getosubp, zcatdir = zcatdir, mock = mock, numobs_from_ledger = numobs_from_ledger, targets = targets, verbose = verbose, debug = debug)
+                
             elif action['ACTIONTYPE'] == 'reproc':
                 #returns timedict
 

--- a/py/LSS/SV3/fatools.py
+++ b/py/LSS/SV3/fatools.py
@@ -571,7 +571,7 @@ def altcreate_mtl(
         log.critical(tiles)
         raise ValueError('When processing tile 315, code should strip out processing of all other tiles. ')
     else:
-        
+    
         d = io.read_targets_in_tiles(
             mtldir,
             tiles,
@@ -603,23 +603,17 @@ def altcreate_mtl(
         keep = (d["SV3_MWS_TARGET"] & mws_mask["BACKUP_BRIGHT"]) == 0
         d = d[keep]
 
-    #AJR added this in/Modified by JL
-    if survey == "sv3":
-        columns = [key for key in minimal_target_columns if key not in d.dtype.names]
-    elif survey == "main":
-        columns = [key for key in minimal_target_columns_main if key not in d.dtype.names]
-    else:
-        raise ValueError('survey must be sv3 or main')
-
     #tcol = ['SV3_DESI_TARGET','SV3_BGS_TARGET','SV3_MWS_TARGET','SV3_SCND_TARGET']
     #for col in tcol:
     #    columns.append(col) 
     if not mock:
         log.info('len(d)= {0}'.format(len(d)))
-
-        d = inflate_ledger(
-                d, targdir, columns=columns, header=False, strictcols=False, quick=True
-            )    # AR adding PLATE_RA, PLATE_DEC, PLATE_REF_EPOCH ?
+        
+        #LGN, we now only run inflate_ledger for SV3
+        if survey == "sv3":
+            columns = [key for key in minimal_target_columns if key not in d.dtype.names]
+            d = inflate_ledger(d, targdir, columns=columns, header=False, strictcols=False, quick=True)    # AR adding PLATE_RA, PLATE_DEC, PLATE_REF_EPOCH ?
+        
         log.info('len(d)= {0}'.format(len(d)))
         if add_plate_cols:
             d = Table(d)


### PR DESCRIPTION
Minor changes to both altmtltools.py and fatools.py functions. I've verified that when survey is main the function inflate_ledger will no longer called. I've tested that this does not prevent loop_alt_ledger from running as intended and that the files generated are identical with/without the inflate_ledger call. This was confirmed by replicating the first full year of the survey.

Optional single_action option added to loop_alt_ledger function which runs only a single action, I've used this in profiling individual runs. It would be possible to add this profiling directly into the altmtltools code, but it seems cleaner to keep separate at this time.