### PR TITLE
Hdf5compression

### DIFF
--- a/Sandbox/testrun_hdf5blosc.py
+++ b/Sandbox/testrun_hdf5blosc.py
@@ -51,3 +51,4 @@ for reg in regions:
 	from multiprocessing import Pool
 	with Pool() as pool:
 		res = pool.map(_parfun, inds)
+common.printlog('finished script',logger)

--- a/Sandbox/testrun_hdf5blosc.py
+++ b/Sandbox/testrun_hdf5blosc.py
@@ -45,7 +45,7 @@ for reg in regions:
 	def _parfun(rannum):
 		indat = fitsio.read(flin+'_'+str(rannum)+'_clustering.ran.fits')
 		out_fn = flin+'_'+str(rannum)+'_clustering.ran.h5'
-		common.write_LSShdf5_scratchcp(indat, outf,logger=None)
+		common.write_LSShdf5_scratchcp(indat, out_fn,logger=logger)
 
 
 	from multiprocessing import Pool

--- a/Sandbox/testrun_hdf5blosc.py
+++ b/Sandbox/testrun_hdf5blosc.py
@@ -36,7 +36,7 @@ ch.setFormatter(formatter)
 logger.addHandler(ch)
 
 
-tracer = 'QSO' #these are the largest size because of their footprint size
+tracer = 'LRG' 
 ddir = '/pscratch/sd/a/ajross/DA2/mocks/SecondGenMocks/AbacusSummit_v4_1/altmtl5/loa-v1/mock5/LSScats/'
 inds = np.arange(18) #18 random files
 regions = ['NGC','SGC']

--- a/Sandbox/testrun_hdf5blosc.py
+++ b/Sandbox/testrun_hdf5blosc.py
@@ -39,7 +39,7 @@ logger.addHandler(ch)
 tracer = 'QSO' #these are the largest size because of their footprint size
 ddir = '/pscratch/sd/a/ajross/DA2/mocks/SecondGenMocks/AbacusSummit_v4_1/altmtl5/loa-v1/mock5/LSScats/'
 inds = np.arange(18) #18 random files
-regsions = ['NGC','SGC']
+regions = ['NGC','SGC']
 for reg in regions:
 	flin = ddir + tracer + '_'+reg
 	def _parfun(rannum):

--- a/Sandbox/testrun_hdf5blosc.py
+++ b/Sandbox/testrun_hdf5blosc.py
@@ -17,6 +17,7 @@ import LSS.common_tools as common
 
 
 # create logger
+import logging
 logname = 'LSSran'
 logger = logging.getLogger(logname)
 logger.setLevel(logging.INFO)

--- a/Sandbox/testrun_hdf5blosc.py
+++ b/Sandbox/testrun_hdf5blosc.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+"""
+Test run converting randoms
+"""
+
+import os, sys, glob
+import numpy as np
+from astropy.table import Table
+
+import fitsio
+import numpy as np
+import h5py
+import hdf5plugin
+
+import LSS.common_tools as common
+
+
+# create logger
+logname = 'LSSran'
+logger = logging.getLogger(logname)
+logger.setLevel(logging.INFO)
+
+# create console handler and set level to debug
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+
+# create formatter
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+# add formatter to ch
+ch.setFormatter(formatter)
+
+# add ch to logger
+logger.addHandler(ch)
+
+
+tracer = 'QSO' #these are the largest size because of their footprint size
+ddir = '/pscratch/sd/a/ajross/DA2/mocks/SecondGenMocks/AbacusSummit_v4_1/altmtl5/loa-v1/mock5/LSScats/'
+inds = np.arange(18) #18 random files
+regsions = ['NGC','SGC']
+for reg in regions:
+	flin = ddir + tracer + '_'+reg
+	def _parfun(rannum):
+		indat = fitsio.read(flin+'_'+str(rannum)+'_clustering.ran.fits')
+		out_fn = flin+'_'+str(rannum)+'_clustering.ran.h5'
+		common.write_LSShdf5_scratchcp(indat, outf,logger=None)
+
+
+	from multiprocessing import Pool
+	with Pool() as pool:
+		res = pool.map(_parfun, inds)

--- a/Sandbox/testrun_hdf5blosc.py
+++ b/Sandbox/testrun_hdf5blosc.py
@@ -35,7 +35,7 @@ ch.setFormatter(formatter)
 # add ch to logger
 logger.addHandler(ch)
 
-
+common.printlog('starting script',logger)
 tracer = 'LRG' 
 ddir = '/pscratch/sd/a/ajross/DA2/mocks/SecondGenMocks/AbacusSummit_v4_1/altmtl5/loa-v1/mock5/LSScats/'
 inds = np.arange(18) #18 random files

--- a/py/LSS/common_tools.py
+++ b/py/LSS/common_tools.py
@@ -1577,6 +1577,9 @@ def reduce_column_precision(table):
     return result
 
 def write_hdf5_blosc(filename, table):
+    import h5py
+    import hdf5plugin #need to be in the cosmodesi test environment, as of Sep 4th 25
+
     """Write table to filename using hdf5 blosc compression; code adapted from Joe DeRose"""
     if os.path.exists(filename):
         print(f'Replacing {filename}')

--- a/py/LSS/common_tools.py
+++ b/py/LSS/common_tools.py
@@ -1586,7 +1586,7 @@ def write_hdf5_blosc(filename, table, extname='LSS',logger=None):
         os.remove(filename)
     tempfilename = filename+'.tmp'
     with h5py.File(tempfilename, 'a') as fn:
-
+        ext = fn.create_group(extname)
         for k in table.dtype.names:
             data = table[k]
             dt = table.dtype[k]
@@ -1594,7 +1594,7 @@ def write_hdf5_blosc(filename, table, extname='LSS',logger=None):
                 dt = 'S1'  
             data = np.array(data, dtype=dt)
             
-            ext = fn.create_group(extname)
+            
             # Using Blosc with default settings
             ext.create_dataset(k, data=data, dtype=dt,
                                 compression=hdf5plugin.Blosc(cname='zstd', clevel=5))

--- a/py/LSS/common_tools.py
+++ b/py/LSS/common_tools.py
@@ -1657,7 +1657,7 @@ def write_LSShdf5_scratchcp(ff, outf,logger=None):
     #shutil.move(tmpfn, outf)
     #os.rename(tmpfn, outf)
     testcol = list(ff.dtype.names)[0]
-    printlog(str(testcol),logger)
+    #printlog(str(testcol),logger)
     try:
         read_hdf5_blosc(tmpfn,columns=[testcol])
     except:

--- a/py/LSS/common_tools.py
+++ b/py/LSS/common_tools.py
@@ -1659,7 +1659,7 @@ def write_LSShdf5_scratchcp(ff, outf,logger=None):
     testcol = list(ff.dtype.names)[0]
     printlog(str(testcol),logger)
     try:
-        read_hdf5_blosc(tmpfn,columns=(testcol))
+        read_hdf5_blosc(tmpfn,columns=[testcol])
     except:
         printwarn('read failed, output corrupted?! '+tmpfn, logger)
         return 'FAILED'    
@@ -1670,7 +1670,7 @@ def write_LSShdf5_scratchcp(ff, outf,logger=None):
     #printlog('checking read of column ' + testcol, logger)
 
     try:
-        read_hdf5_blosc(outf.replace('global','dvs_ro'),columns=(testcol))
+        read_hdf5_blosc(outf.replace('global','dvs_ro'),columns=[testcol])
         df = 1
     except:
         printwarn('read failed, copy failed?! check temporary file '+tmpfn, logger)

--- a/py/LSS/common_tools.py
+++ b/py/LSS/common_tools.py
@@ -1671,7 +1671,7 @@ def write_LSShdf5_scratchcp(ff, outf,logger=None):
     #os.system('cp ' + tmpfn + ' ' + outf) 
     outftmp = outf+'.tmp'
     shutil.copy2(tmpfn,outftmp)
-    os.rename(outftmp,outf
+    os.rename(outftmp,outf)
     #os.system('chmod 775 ' + outf) #this should fix permissions for the group
     os.chmod(outf,755)
     printlog('moved output to ' + outf, logger)

--- a/py/LSS/common_tools.py
+++ b/py/LSS/common_tools.py
@@ -1640,7 +1640,7 @@ def write_LSShdf5_scratchcp(ff, outf,logger=None):
     import shutil
     printlog('will write to '+outf,logger)
     ff = reduce_column_precision(Table(ff)) #convert data types to save storage space
-    common.printlog('reduced precision of input',logger)
+    printlog('reduced precision of input',logger)
     rng = np.random.default_rng()#seed=rann)
     ranstring = int(rng.random()*1e10)
     tmpfn = os.getenv('SCRATCH')+'/'+outf.split('/')[-1] + '.tmp'+str(ranstring)

--- a/py/LSS/common_tools.py
+++ b/py/LSS/common_tools.py
@@ -1657,6 +1657,7 @@ def write_LSShdf5_scratchcp(ff, outf,logger=None):
     #shutil.move(tmpfn, outf)
     #os.rename(tmpfn, outf)
     testcol = list(ff.dtype.names)[0]
+    printlog(str(testcol),logger)
     try:
         read_hdf5_blosc(tmpfn,columns=(testcol))
     except:
@@ -1669,7 +1670,7 @@ def write_LSShdf5_scratchcp(ff, outf,logger=None):
     #printlog('checking read of column ' + testcol, logger)
 
     try:
-        fitsio.read(outf.replace('global','dvs_ro'),columns=(testcol))
+        read_hdf5_blosc(outf.replace('global','dvs_ro'),columns=(testcol))
         df = 1
     except:
         printwarn('read failed, copy failed?! check temporary file '+tmpfn, logger)

--- a/py/LSS/common_tools.py
+++ b/py/LSS/common_tools.py
@@ -1658,7 +1658,7 @@ def write_LSShdf5_scratchcp(ff, outf,logger=None):
     #os.rename(tmpfn, outf)
     testcol = list(ff.dtype.names)[0]
     try:
-        fitsio.read(tmpfn,columns=(testcol))
+        read_hdf5_blosc(tmpfn,columns=(testcol))
     except:
         printwarn('read failed, output corrupted?! '+tmpfn, logger)
         return 'FAILED'    
@@ -1680,12 +1680,14 @@ def write_LSShdf5_scratchcp(ff, outf,logger=None):
         os.system('rm '+tmpfn)
     return True
 
-def read_hdf5_blosc(filename):
+def read_hdf5_blosc(filename,columns=None):
     import h5py
     import hdf5plugin #need to be in the cosmodesi test environment, as of Sep 4th 25
     data = Table()
     with h5py.File(filename) as fn:
-        for col in fn.keys():
+        if columns is None:
+            columns = fn.keys()
+        for col in columns:
             data[col] = fn[col][:]
 
     return data

--- a/py/LSS/common_tools.py
+++ b/py/LSS/common_tools.py
@@ -1673,7 +1673,7 @@ def write_LSShdf5_scratchcp(ff, outf,logger=None):
     shutil.copy2(tmpfn,outftmp)
     os.rename(outftmp,outf)
     #os.system('chmod 775 ' + outf) #this should fix permissions for the group
-    os.chmod(outf,755)
+    os.chmod(outf,775)
     printlog('moved output to ' + outf, logger)
     df = 0
     #printlog('checking read of column ' + testcol, logger)


### PR DESCRIPTION
Functions have been added for the compression/writing/reading of hdf5 files.

A script to test the performance is Sandbox/testrun_hdf5blosc.py

This reformats all 18 NGC/SGC randoms for LRGs from one of the DR2 altmtl LSS catalogs. It runs in 34 seconds. The storage space is reduced by a factor 5.6 (from 46 to 8 GB).
