### PR TITLE
Add option to xirunpc to save off weighted data/random sums for jackknife density realizations

### DIFF
--- a/py/LSS/common_tools.py
+++ b/py/LSS/common_tools.py
@@ -6,6 +6,9 @@ import os
 import sys
 import logging
 
+from pycorr.twopoint_counter import get_inverse_probability_weight
+from pycorr.twopoint_estimator import _get_project_mode, project_to_poles, project_to_wp, project_to_wedges, TwoPointEstimatorError
+
 ext_coeff = {'G':3.214, 'R':2.165,'Z':1.211,'W1':0.184,'W2':0.113}
 
 from LSS.tabulated_cosmo import TabulatedDESI
@@ -1961,3 +1964,98 @@ def apply_wntmp(ntile, f_ntmisspw, f_ntzp, ntile_range=[0,15], randoms=True):
             if 1-f_ntmisspw[n] > 0: w_ntmisspw[idx_nt[n][0]] = 1/(1-f_ntmisspw[n])
         
     return w_ntmisspw, w_ntzp
+
+
+def calculate_density_realizations(data_labels, data_weights, randoms_labels, randoms_weights, n_jack):
+    """
+    Calculate density realizations from jackknife samples.
+    """
+    def weighted_sum_per_subsample(samples, weights):
+        # For each region k, we want the weighted count NOT in region k
+        wt = get_inverse_probability_weight(weights) # If you use bitwise weights, compute IIP. TODO alternatives?
+        total = np.sum(wt)
+        bincount = np.bincount(samples, weights=wt, minlength=n_jack)
+        not_in_k = total - bincount
+        return not_in_k
+
+    wsum_data = weighted_sum_per_subsample(data_labels, data_weights)
+    wsum_randoms = weighted_sum_per_subsample(randoms_labels, randoms_weights)
+    density_realizations = wsum_data / wsum_randoms
+
+    return density_realizations
+
+
+def get_cov_with_ndens(estimator, density_realizations, return_sep=True, mode='auto', **kwargs):
+    """
+    Returns correlation function and covariance matrix extended with number density.
+
+    This function is a modified version of the BaseTwoPointEstimator.get_corr()
+    method. It calculates the covariance matrix from jackknife realizations,
+    adding an extra row/column for the number density fluctuations.
+
+    Parameters
+    ----------
+    estimator : BaseTwoPointEstimator
+        The estimator object, which must contain jackknife realizations.
+    density_realizations : array
+        An array of number density values for each jackknife realization.
+    return_sep : bool, default=True
+        Whether to return the separation bins.
+    mode : str, default='auto'
+        The projection mode ('poles', 'wp', 'wedges', etc.).
+    kwargs : dict
+        Arguments to be passed to the projection function. Provide ells, a list of multipoles, for 'poles' mode;
+        pimax for 'wp' mode; or mu_bins for 'wedges' mode. See the documentation of the projection functions for details.
+
+    Returns
+    -------
+    sep : array
+        Separation values (if return_sep=True).
+    corr : array
+        The mean correlation function.
+    cov : array
+        The extended covariance matrix including number density.
+    """
+
+    # Determine projection mode from arguments
+    mode, kwargs_proj = _get_project_mode(mode=mode, **kwargs)
+
+    # Define the projection function based on the mode
+    if mode == 'poles':
+        proj_func = project_to_poles
+    elif mode == 'wedges':
+        proj_func = project_to_wedges
+    elif mode == 'wp':
+        proj_func = project_to_wp
+    else:
+        raise TwoPointEstimatorError(f"Mode '{mode}' is not supported for covariance calculation with ndens.")
+
+    # 1. Get the mean correlation function and separation bins
+    toret = proj_func(estimator, return_sep=return_sep, return_cov=False, **kwargs_proj)
+    if return_sep:
+        sep, corr = toret
+    else:
+        sep, corr = None, toret
+
+    # 2. Build the extended realizations for covariance calculation
+    if not hasattr(estimator, 'realizations'):
+        raise TwoPointEstimatorError('Input estimator has no jackknife realizations to compute covariance.')
+
+    extended_realizations = []
+    nbar = np.mean(density_realizations)
+
+    for i in estimator.realizations:
+        # Project the correlation function for this jackknife realization
+        corr_real = proj_func(estimator.realization(i), return_sep=False, return_cov=False, **kwargs_proj).ravel()
+
+        # Append the normalized density to the correlation function vector
+        extended_real = np.append(corr_real, density_realizations[i] / nbar)
+        extended_realizations.append(extended_real)
+
+    # 3. Calculate the full covariance matrix from the extended realizations
+    cov = (len(extended_realizations) - 1) * np.cov(extended_realizations, rowvar=False, ddof=0)
+
+    # 4. Format the return tuple
+    if return_sep:
+        return sep, corr, cov
+    return corr, cov

--- a/scripts/xirunpc.py
+++ b/scripts/xirunpc.py
@@ -22,6 +22,7 @@ from matplotlib import pyplot as plt
 
 from pycorr import TwoPointCorrelationFunction, TwoPointEstimator, KMeansSubsampler, utils, setup_logging
 
+from LSS.common_tools import calculate_density_realizations
 from LSS.tabulated_cosmo import TabulatedDESI
 import LSS.cosmodesi_io_tools as io
 import sys
@@ -89,6 +90,7 @@ def compute_angular_weights(nthreads=8, gpu=False, dtype='f8', tracer='ELG', tra
 
 def compute_correlation_function(corr_type, edges, distance, nthreads=8, gpu=False, dtype='f8', wang=None, split_randoms_above=30., weight_type='default', tracer='ELG', tracer2=None, recon_dir=None, rec_type=None, njack=120, nradjack=1, option=None, mpicomm=None, mpiroot=None, cat_read=None, dat_cat=None, ran_cat=None, rpcut=None, thetacut=None,nreal=129, **kwargs):
 
+    density_realizations = None
     autocorr = tracer2 is None
     catalog_kwargs = kwargs.copy()
     catalog_kwargs['weight_type'] = weight_type
@@ -211,14 +213,29 @@ def compute_correlation_function(corr_type, edges, distance, nthreads=8, gpu=Fal
                     else:
                         array = np.concatenate(arrays, axis=0)
                     tmp_randoms_kwargs[name] = array
+
+            logger.info(f'Computing {corr_type} correlation function for random set {iran+1} of {nran} with edges {edges}')
             tmp = TwoPointCorrelationFunction(corr_type, edges, data_positions1=data_positions1, data_weights1=data_weights1, data_samples1=data_samples1,
                                               data_positions2=data_positions2, data_weights2=data_weights2, data_samples2=data_samples2,
                                               engine='corrfunc', position_type='rdd', nthreads=nthreads, gpu=gpu, dtype=dtype, **tmp_randoms_kwargs, **kwargs,
                                               D1D2=D1D2, mpicomm=mpicomm, mpiroot=mpiroot, selection_attrs=selection_attrs,weight_attrs={'normalization': 'counter','nrealizations':nreal}) 
+            
+            # TODO SHOULD I ADD IN NUMBER DENSITY STUFF HERE? 
+            # All info is available but where will it get saved? TwoPointCorrelationFunction would need modifications to save it with that.
+            # Save it in a different file?
+            # If I don't do it here, and it's an extra method you can call totalyl outside all this, then you have to reproduce the labelling of data for the jackknives 
+            # IN order to correctly count the number of objects in each jackknife region. 
+            # Speaking of: Arnaud's code for counting objects does it in each jackknife region, not in everything else MINUS that region, which seems wrong to me?
+            # As in, Realization 1: excludes region 1 when pair counting (effectively), so should exclude region 1 when counting objects too, right? Confusing.
+            if args.ndens_cov:
+                # TODO understand and deal with i_split_randoms
+                #density_realizations = calculate_density_realizations(data_samples1, data_weights1, randoms_samples1 if not i_split_randoms else tmp_randoms_kwargs['randoms_samples1'], randoms_weights1 if not i_split_randoms else tmp_randoms_kwargs['randoms_weights1'], n_jack * nradjack if data_samples1 is not None else 1)
+                density_realizations = calculate_density_realizations(data_samples1, data_weights1, randoms_samples1, randoms_weights1, args.njack*args.nradjack)
+            
             D1D2 = tmp.D1D2
             result += tmp
         results.append(result)
-    return results[0].concatenate_x(*results), wang
+    return results[0].concatenate_x(*results), wang, density_realizations
 
 
 def get_edges(corr_type='smu', bin_type='lin'):
@@ -284,6 +301,8 @@ def corr_fn(file_type='npy', region='', tracer='ELG', tracer2=None, zmin=0, zmax
         root += '_thetacut{}'.format(thetacut)
     if file_type == 'npy':
         return os.path.join(out_dir, 'allcounts_{}.npy'.format(root))
+    if file_type == 'ndens':
+        return os.path.join(out_dir, 'ndens_{}.npy'.format(root))
     return os.path.join(out_dir, '{}_{}.txt'.format(file_type, root))
 
 
@@ -310,6 +329,7 @@ if __name__ == '__main__':
                                                    see https://arxiv.org/pdf/1905.01133.pdf', type=float, default=20)
     parser.add_argument('--njack', help='number of angular jack-knife subsamples; < 2 for no jack-knife error estimates', type=int, default=0)
     parser.add_argument('--nradjack', help='number of radial jack-knife subsamples; total jack-knives are njack*nradjack', type=int, default=1)
+    parser.add_argument('--ndens_cov', help='whether to add in a number density column to the covariance matrix (use with njack)', default='n')
     parser.add_argument('--gpu', help='whether to run on the GPU', action='store_true')
     parser.add_argument('--nthreads', help='number of threads (defaults to 4 if --gpu else 128)', type=int, default=None)
     parser.add_argument('--outdir', help='base directory for output (default: SCRATCH)', type=str, default=None)
@@ -340,6 +360,13 @@ if __name__ == '__main__':
         args.rebinning = False
     if args.rebinning == 'y':
         args.rebinning = True
+
+    if args.ndens_cov == 'y' and args.njack > 1:
+        args.ndens_cov = True
+    elif args.ndens_cov == 'n':
+        args.ndens_cov = False
+    else:
+        raise ValueError('ndens_cov must be y or n')
 
     mpicomm, mpiroot = None, None
     if True:#args.mpi:
@@ -468,15 +495,17 @@ if __name__ == '__main__':
                     logger.info('Computing correlation function {} in region {} in redshift range {}.'.format(corr_type, region, (zmin, zmax)))
                 edges = get_edges(corr_type=corr_type, bin_type=args.bin_type)
             
-                result, wang = compute_correlation_function(corr_type, edges=edges, distance=distance, nrandoms=args.nran, split_randoms_above=args.split_ran_above, nthreads=nthreads, gpu=gpu, region=region, zlim=(zmin, zmax), maglim=maglims, weight_type=args.weight_type, njack=args.njack, nradjack=args.nradjack, wang=wang, mpicomm=mpicomm, mpiroot=mpiroot, option=option, rpcut=args.rpcut, thetacut=args.thetacut,nreal=args.nreal, **catalog_kwargs)
+                result, wang, ndens = compute_correlation_function(corr_type, edges=edges, distance=distance, nrandoms=args.nran, split_randoms_above=args.split_ran_above, nthreads=nthreads, gpu=gpu, region=region, zlim=(zmin, zmax), maglim=maglims, weight_type=args.weight_type, njack=args.njack, nradjack=args.nradjack, wang=wang, mpicomm=mpicomm, mpiroot=mpiroot, option=option, rpcut=args.rpcut, thetacut=args.thetacut,nreal=args.nreal, **catalog_kwargs)
                 # Save pair counts
                 if mpicomm is None or mpicomm.rank == mpiroot:
                     result.save(corr_fn(file_type='npy', region=region, out_dir=os.path.join(out_dir, corr_type), **base_file_kwargs))
             if mpicomm is None or mpicomm.rank == mpiroot:
-                 if wang is not None:
-                        for name in wang:
-                            if wang[name] is not None:
-                                wang[name].save(corr_fn(file_type='npy', region=region, out_dir=os.path.join(out_dir, 'wang'), **base_file_kwargs, wang=name))
+                if wang is not None:
+                    for name in wang:
+                        if wang[name] is not None:
+                            wang[name].save(corr_fn(file_type='npy', region=region, out_dir=os.path.join(out_dir, 'wang'), **base_file_kwargs, wang=name))
+                if ndens is not None:
+                    np.save(corr_fn(file_type='ndens', region=region, out_dir=os.path.join(out_dir, corr_type), **base_file_kwargs), ndens)
 
         # Save combination and .txt files
         for corr_type in args.corr_type:


### PR DESCRIPTION
Add option to xirunpc to save off weighted data/random sums for jackknife density realizations. The downstream code that uses this is in the cosmodesi/desi-y3-gqp repo.