### PR TITLE
Support .npz bin edge files via --bin_type to allow unequal numbers of bin edges in 2D

### DIFF
--- a/scripts/xirunpc.py
+++ b/scripts/xirunpc.py
@@ -236,6 +236,60 @@ def compute_correlation_function(corr_type, edges, distance, nthreads=8, gpu=Fal
 
 
 def get_edges(corr_type='smu', bin_type='lin'):
+    """
+    Return bin-edge arrays for the requested 2-point correlation-function measurement.
+
+    This helper centralizes the definition (or loading) of the bin edges used by
+    :class:`pycorr.TwoPointCorrelationFunction` within this script.
+
+    Parameters
+    ----------
+    corr_type : {{'smu', 'rppi', 'theta'}}, default='smu'
+        The correlation-function parameterization
+    bin_type : str, default='lin'
+        Binning specification. Supported values depend on ``corr_type``:
+        **Built-in presets**
+            - ``'lin'``: use the script's default linear binning for the given ``corr_type``.
+            - ``'log'``: use the script's default logarithmic binning (where applicable).
+        **Custom binning from files**
+            - Path to an ``.npz`` file:
+                Load edges from a NumPy archive created with ``numpy.savez``.
+                The archive must contain 1D edge arrays with names depending on ``corr_type``:
+
+                - ``corr_type == 'rppi'``: arrays ``'rp'`` and ``'pi'``
+                - ``corr_type == 'smu'`` : arrays ``'s'`` and ``'mu'``
+                - ``corr_type == 'theta'``: array ``'theta'``
+                This mode supports edge arrays of different lengths
+            - Path to a text file readable by ``numpy.loadtxt``:
+                If the file loads as a 1D array, it is interpreted as the edges for the
+                primary axis (``s`` for ``smu``, ``rp`` for ``rppi``, or ``theta`` for ``theta``),
+                with the secondary axis falling back to the default for that ``corr_type``.
+                If the file loads as a 2D array, the first two rows are interpreted as
+                the edges for the two axes (e.g. ``(rp_edges, pi_edges)`` for ``rppi``).
+                The two rows must be the same length.
+
+
+    Returns
+    -------
+    edges : tuple of ndarray
+        Tuple of one or two 1D NumPy arrays containing bin edges:
+        - for ``'smu'`` : ``(s_edges, mu_edges)``
+        - for ``'rppi'``: ``(rp_edges, pi_edges)``
+        - for ``'theta'``: ``(theta_edges,)``
+        Edge arrays are monotonically increasing and define ``N-1`` bins for ``N`` edges.
+    """
+
+
+    if isinstance(bin_type, str) and bin_type.endswith('.npz'):
+        dat = np.load(bin_type)
+        if corr_type == 'rppi':
+            return (dat['rp'], dat['pi'])
+        elif corr_type == 'smu':
+            return (dat['s'], dat['mu'])
+        elif corr_type == 'theta':
+            return (dat['theta'],)
+        else:
+            raise ValueError('corr_type must be one of ["smu", "rppi", "theta"]')
 
     if corr_type == 'smu':
         if bin_type == 'log':


### PR DESCRIPTION
This PR allows us to use a different number of bins in rp and pi (or s, mu) when we compute the 2D correlation function. This is useful because it let's us calculate the QSO auto on the same 2D grid as the LyA forest-QSO cross-correlation. (The LyA WG calculates the forest cross with twice as many r_par bins as r_perp bins.)

The change is needed because get_edges() currently only accommodates a .txt file that is read with np.loadtxt(), and np.loadtxt() requires that every row has the same number of columns. 

The new code detects if the argument to a --bin_type is a .npz file and reads separate arrays for the two dimensions with np.load(). Note that the code change to get_edges() is backwards compatible to the case where --bin_type is a .txt file. One could also put the same number of bin edges in both dimensions in a .npz file. 

Here is an example of how to create such a .npz file:

```
#!/usr/bin/env python3
"""
Script to generate and save bin edges for 2D correlation function (r_p, pi).
Default: rp [0, 200], pi [-200, 200] with 4 Mpc/h steps.
"""

import numpy as np
import argparse
import os

def main():
    # Setup Argument Parser for flexibility
    parser = argparse.ArgumentParser(description="Generate bin edges for pycorr rppi mode.")
    parser.add_argument("--rp_max", type=float, default=200, help="Max transverse separation")
    parser.add_argument("--pi_max", type=float, default=200, help="Max parallel separation (plotted as +/- max)")
    parser.add_argument("--step", type=float, default=4, help="Bin width")
    parser.add_argument("--out", type=str, help="Custom output filename")

    args = parser.parse_args()

    # Define the bins
    # We use + args.step to ensure the stop value is inclusive if desired
    rp = np.arange(0, args.rp_max + args.step, args.step, dtype='f8')
    pi = np.arange(-args.pi_max, args.pi_max + args.step, args.step, dtype='f8')

    # Generate filename if not provided
    if args.out:
        filename = args.out
    else:
        filename = f"bins_rppi_rp0_{int(args.rp_max)}_pi-{int(args.pi_max)}_{int(args.pi_max)}_step{int(args.step)}.npz"

    # Save and print confirmation
    np.savez(filename, rp=rp, pi=pi)
    print(f"Successfully saved bins to: {filename}")
    print(f"rp bins: {len(rp)-1} | pi bins: {len(pi)-1}")

if __name__ == "__main__":
    main()
```