### PR TITLE
New QSO catalog generation script

### DIFF
--- a/py/LSS/SV3/altmtltools.py
+++ b/py/LSS/SV3/altmtltools.py
@@ -1317,11 +1317,21 @@ def make_fibermaps(altmtldir, OrigFAs, AltFAs, AltFAs2, TSs, fadates, tiles, sur
 def to_big_endian_table(tab):
     arr = tab.as_array()
 
-    # LGN 20260609 Checking if table is already big endian 
-    if arr.dtype.byteorder in ('>', '|'):
-        # already big-endian or byte-order independent
+    # Determine whether any field needs conversion
+    needs_conversion = False
+    for name in arr.dtype.names:
+        dt = arr.dtype[name]
+
+        if dt.byteorder == '<':
+            needs_conversion = True
+            break
+        if dt.byteorder == '=' and np.little_endian:
+            needs_conversion = True
+            break
+
+    if not needs_conversion:
         return tab.copy()
-    
+
     arr_be = arr.byteswap().view(arr.dtype.newbyteorder('>'))
     return Table(arr_be)
     

--- a/py/LSS/SV3/altmtltools.py
+++ b/py/LSS/SV3/altmtltools.py
@@ -1312,6 +1312,19 @@ def make_fibermaps(altmtldir, OrigFAs, AltFAs, AltFAs2, TSs, fadates, tiles, sur
         log.info('write_amtl_tile_tracker retval = {0}'.format(retval))
 
     return A2RMap, R2AMap
+
+# LGN 20260609 Moving endian conversion helper outside of update_alt_ledger 
+def to_big_endian_table(tab):
+    arr = tab.as_array()
+
+    # LGN 20260609 Checking if table is already big endian 
+    if arr.dtype.byteorder in ('>', '|'):
+        # already big-endian or byte-order independent
+        return tab.copy()
+    
+    arr_be = arr.byteswap().view(arr.dtype.newbyteorder('>'))
+    return Table(arr_be)
+    
 def update_alt_ledger(altmtldir,althpdirname, altmtltilefn,  actions, survey = 'sv3', obscon = 'dark', today = None, 
     getosubp = False, zcatdir = None, mock = False, numobs_from_ledger = True, targets = None, verbose = False, debug = False, zfix = None):
     if verbose or debug:
@@ -1367,6 +1380,9 @@ def update_alt_ledger(altmtldir,althpdirname, altmtltilefn,  actions, survey = '
         log.info('zcatdir = {0}'.format(zcatdir))
         log.info('t = {0}'.format(t))
         zcat = make_zcat(zcatdir, [t], obscon, survey)
+
+        # LGN Bug fix - converting zcat from little to big endianness
+        zcat = to_big_endian_table(zcat)
 
         altZCat = makeAlternateZCat(zcat, R2AMap, A2RMap, debug = debug, verbose = verbose)
         # ADM insist that for an MTL loop with real observations, the zcat

--- a/py/LSS/SV3/fatools.py
+++ b/py/LSS/SV3/fatools.py
@@ -437,14 +437,9 @@ def get_fba_fromnewmtl(tileid,mtldir=None,getosubp=False,outdir=None,faver=None,
                 fo.write("module swap fiberassign/"+fht['FA_VER'][:3]+'.0'+"\n")
         elif faver >= 2.4 and faver < 4.0:
             fo.write("module swap fiberassign/"+fht['FA_VER']+"\n")
-        elif faver >= 4.0 and faver < 5.0:
-            #fo.write("module swap fiberassign/5.0.0\n")
-            fo.write("export PATH=/global/cfs/cdirs/desi/users/raichoor/fiberassign-rerun-main/fiberassign_main_godesi23.10/bin:$PATH\n")
-            fo.write("export PYTHONPATH=/global/cfs/cdirs/desi/users/raichoor/fiberassign-rerun-main/fiberassign_main_godesi23.10/py:$PYTHONPATH\n")
-            fo.write("export SKYHEALPIXS_DIR=$DESI_ROOT/target/skyhealpixs/v1\n")
         else:
-            #with fiberassign refactor as of May 2025, it is no longer necessary to specify a module swap for faver > 5.00
-            assert faver >= 5.0
+            # 20260610 LGN - Testing shows that we can now use the standard desi environment for all main survey tiles
+            assert faver >= 4.0
     else:
         fo.write("module swap fiberassign/"+str(faver)+"\n")
         faver = float(faver[:3])
@@ -471,7 +466,8 @@ def get_fba_fromnewmtl(tileid,mtldir=None,getosubp=False,outdir=None,faver=None,
     if faver >= 3:
         fo.write(" --ha "+str(fht['FA_HA']))
         fo.write(" --margin-gfa 0.4 --margin-petal 0.4 --margin-pos 0.05")
-    if faver >=5:
+
+    if faver >=4:
         fo.write(" --fafns_for_stucksky "+fa_fn)
     fo.close()    
 

--- a/scripts/mock_tools/sbatch/holi_v3_elgimlin_jobarray.sl
+++ b/scripts/mock_tools/sbatch/holi_v3_elgimlin_jobarray.sl
@@ -4,7 +4,7 @@
 #SBATCH --constraint=cpu
 #SBATCH -q regular
 #SBATCH -t 00:20:00
-#SBATCH --array=0,12,13,14
+#SBATCH --array=0-50
 #this can be used for any jobs that timed out
 source /global/common/software/desi/desi_environment.sh main
 module load LSS/main
@@ -13,4 +13,4 @@ mocknum=$SLURM_ARRAY_TASK_ID
 scriptdir=/global/homes/d/desica/LSScode/LSS/scripts
 sim=holi_v3
 
-srun python $scriptdir/mock_tools/mkCat_amtl.py --base_altmtl_dir /global/cfs/cdirs/desi/mocks/cai/LSS/ --outmd cfs --simName $sim --mocknum $mocknum --survey DA2 --specdata loa-v1 --tracer ELG --notqso y  --doimlin y --par y --imsys_zbin split
+srun python $scriptdir/mock_tools/mkCat_amtl.py --base_altmtl_dir /global/cfs/cdirs/desi/mocks/cai/LSS/ --outmd cfs --simName $sim --mocknum $mocknum --survey DA2 --specdata loa-v1 --tracer ELG_LOP --notqso y  --doimlin y --par y --imsys_zbin split


### PR DESCRIPTION
This PR adds the new script: scripts/main/mkQSO_v2.py to generate QSO catalogs. The script works with redshift catalogs in the "v2" format and produces catalogs of both all QSOs and "only_qso_targets". 

Members of the LyA WG have confirmed that these catalogs contain the columns we need to run tools to identify BALs, DLAs, create healpix-based spectrum coadds, and generate mocks. 