### PR TITLE
badfiber_time: add interactive focal plane viewer and per-petal mosaics

### DIFF
--- a/scripts/validation/badfiber_time/README.md
+++ b/scripts/validation/badfiber_time/README.md
@@ -110,3 +110,51 @@ Exposure timestamps from:
 
 LRG nsig values (MC significance of fiber badness) from:
 `krolewski-pipeline/summaryscale/LRGfibersim_matterhorn-v2.txt`
+
+---
+
+## Interactive Focal Plane Viewer (LRG)
+
+*J. Rohlf & Claude Sonnet 4.6 (2026)*
+
+A self-contained HTML viewer showing all 5000 DESI fibers on the focal plane with clickable time plots.
+
+- **Green dots** — active fibers; **orange dots** — Krolewski bad fibers (nsig ≤ −4)
+- Hover over a dot to see fiber number, petal, and σ
+- Click a dot to display its failure rate vs time plot (with survey average and model prediction)
+- Goto box: jump to any fiber by number
+- Save plot button: opens current time plot as PNG for saving
+
+### Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `make_petal_focal_data.py` | Extracts per-petal time series + all focal plane positions into JSON |
+| `make_focal_viewer_multi.py` | Builds self-contained HTML viewer for one or more petals |
+| `plot_petal_mosaic.py` | 5×100 mosaic of all 500 fibers in a petal (PNG + PDF) |
+
+### Build
+
+```bash
+# Extract focal data for all petals (~2 min each)
+for p in 0 1 2 3 4 5 6 7 8 9; do
+    python make_petal_focal_data.py --petal $p
+done
+
+# Interactive viewer (all 10 petals, ~3.9 MB HTML)
+python make_focal_viewer_multi.py --petals 0 1 2 3 4 5 6 7 8 9
+
+# Per-petal mosaics (~8 min each, PNG + PDF)
+for p in 0 1 2 3 4 5 6 7 8 9; do
+    python plot_petal_mosaic.py --petal $p
+done
+```
+
+### Outputs (written to `/global/u1/r/rohlf/bao_jr/dr3-matterhorn-checks/all-fibers-vs-time/`)
+
+| File | Description |
+|------|-------------|
+| `lrg_petal{0..9}_focal_data.json` | Per-petal JSON (~470 KB each) |
+| `lrg_petals0_1_2_3_4_5_6_7_8_9_focal_viewer.html` | All-10-petal interactive viewer |
+| `lrg_petal{0..9}_mosaic.png` | 5×100 mosaic per petal |
+| `lrg_petal{0..9}_mosaic.pdf` | 5×100 mosaic per petal (PDF, ~1.5 MB each) |

--- a/scripts/validation/badfiber_time/make_focal_viewer_multi.py
+++ b/scripts/validation/badfiber_time/make_focal_viewer_multi.py
@@ -1,0 +1,465 @@
+"""
+make_focal_viewer_multi.py
+Interactive focal-plane viewer showing multiple petals simultaneously.
+Each petal gets its own accent colour; bad fibers are orange regardless of petal.
+
+Usage:
+  python make_focal_viewer_multi.py --petals 0 7
+"""
+import argparse, json, os
+parser = argparse.ArgumentParser()
+parser.add_argument('--petals', type=int, nargs='+', default=[0, 7])
+args = parser.parse_args()
+PETALS = args.petals
+
+DATADIR  = '/global/u1/r/rohlf/bao_jr/dr3-matterhorn-checks/all-fibers-vs-time'
+label    = '_'.join(str(p) for p in PETALS)
+out_path = f'{DATADIR}/lrg_petals{label}_focal_viewer.html'
+
+# load each petal JSON
+petal_data = {}
+for p in PETALS:
+    jp = f'{DATADIR}/lrg_petal{p}_focal_data.json'
+    with open(jp) as f:
+        petal_data[p] = json.load(f)
+
+# all_positions is the same for every petal — just use the first
+all_positions = petal_data[PETALS[0]]['all_positions']
+bins_mjd  = petal_data[PETALS[0]]['bins_mjd']
+survey_fr = petal_data[PETALS[0]]['survey_fr']
+survey_er = petal_data[PETALS[0]]['survey_er']
+
+# merge fibers dict: key = str(fiberId), value = fiber record + 'petal' field
+fibers_merged = {}
+for p in PETALS:
+    for fid, rec in petal_data[p]['fibers'].items():
+        r2 = dict(rec)
+        r2['petal'] = p
+        fibers_merged[fid] = r2
+
+combined = {
+    'petals':       PETALS,
+    'all_positions': all_positions,
+    'bins_mjd':     bins_mjd,
+    'survey_fr':    survey_fr,
+    'survey_er':    survey_er,
+    'fibers':       fibers_merged,
+}
+raw_json = json.dumps(combined, separators=(',', ':'))
+
+# one accent colour per petal (index into PETALS list)
+PETAL_COLORS = ['#7878a0', '#4a9a6a', '#6a9aca', '#ca7a4a',
+                '#9a6aca', '#ca4a6a', '#4acaaa', '#caaa4a',
+                '#aa4aca', '#4a7aca']
+
+HTML = """<title>DESI Focal Plane — LRG redshift failures</title>
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+body{background:#13131a;color:#c8c8d8;font-family:ui-monospace,'SF Mono',Menlo,monospace;
+     display:flex;flex-direction:column;height:100vh;overflow:hidden}
+header{padding:10px 18px 8px;border-bottom:1px solid #252530;display:flex;align-items:baseline;
+       gap:12px;flex-shrink:0;flex-wrap:wrap}
+.htitle{font-size:.82rem;letter-spacing:.08em;color:#e0e0f0;font-weight:700}
+.hmeta{font-size:.70rem;color:#9898b8;font-weight:600}
+.pleg{display:flex;gap:10px;margin-left:auto}
+.credit{font-size:.60rem;color:#7070a0;letter-spacing:.04em;margin-left:16px;align-self:center;white-space:nowrap}
+.pchip{font-size:.62rem;padding:2px 7px;border-radius:2px;border:1px solid}
+main{display:flex;flex:1;overflow:hidden}
+#fp-wrap{flex-shrink:0;display:flex;align-items:center;justify-content:center;
+          padding:14px 10px 10px 14px;border-right:1px solid #252530}
+#fp-canvas{cursor:crosshair;display:block}
+#tooltip{position:fixed;pointer-events:none;background:#1e1e2c;border:1px solid #38384a;
+          border-radius:3px;padding:5px 9px;font-size:.65rem;color:#dde;opacity:0;
+          transition:opacity .1s;z-index:99;white-space:nowrap}
+#plot-wrap{flex:1;display:flex;flex-direction:column;padding:14px 16px 10px;overflow:hidden;min-width:0}
+#fiber-title{font-size:.95rem;color:#e0e0f0;margin-bottom:8px;letter-spacing:.03em;min-height:1.4em}
+#plot-canvas{display:block;max-width:100%}
+#legend{display:flex;gap:22px;margin-top:10px;font-size:.78rem;color:#6a6a80}
+.leg{display:flex;align-items:center;gap:5px}
+.lsw{width:20px;height:2px}
+.lsw-sv{background:rgba(190,190,215,.45);height:6px;border-radius:1px}
+#goto-box{display:flex;align-items:center;gap:8px;padding:6px 0 2px;flex-basis:100%}
+#goto-input{background:#1e1e2c;border:1px solid #38384a;color:#e0e0f0;
+             font-family:inherit;font-size:.85rem;padding:5px 10px;width:90px;
+             border-radius:3px;outline:none}
+#goto-input:focus{border-color:#5a5a7a}
+#goto-input.error{border-color:#c03030}
+#goto-btn{background:#252535;border:1px solid #38384a;color:#c8c8d8;
+           font-family:inherit;font-size:.85rem;padding:5px 14px;
+           border-radius:3px;cursor:pointer}
+#goto-btn:hover{background:#32324a}
+#goto-label{font-size:.72rem;color:#55556a;letter-spacing:.05em;text-transform:uppercase}
+.lsw-md{background:repeating-linear-gradient(90deg,#aaa 0,#aaa 4px,transparent 4px,transparent 7px);height:2px;border:none}
+.save-btn{background:#1e2830;border:1px solid #2e4050;color:#88aac0;
+           font-family:inherit;font-size:.72rem;padding:4px 10px;
+           border-radius:3px;cursor:pointer;letter-spacing:.03em}
+.save-btn:hover{background:#253545;color:#aaccdd}
+#img-overlay{display:none;position:fixed;inset:0;background:rgba(0,0,0,.85);
+             z-index:200;flex-direction:column;align-items:center;justify-content:center;gap:10px}
+#img-overlay.show{display:flex}
+#img-overlay img{max-width:95vw;max-height:88vh;border:1px solid #38384a}
+#img-overlay-hint{color:#9898b8;font-size:.72rem;letter-spacing:.05em}
+#img-overlay-close{color:#6a6a80;font-size:.72rem;cursor:pointer;text-decoration:underline}
+</style>
+
+<div id="tooltip"></div>
+<div id="img-overlay">
+  <img id="img-overlay-img" src="" alt="saved image">
+  <div id="img-overlay-hint">Right-click → Save image as…</div>
+  <div id="img-overlay-close">close</div>
+</div>
+<header>
+  <span class="htitle">DESI Focal Plane — LRG Redshift failures</span>
+  <span class="hmeta">hover to identify · click for time plot · orange = bad fiber</span>
+  <div class="pleg" id="pleg"></div>
+  <span class="credit">J. Rohlf &amp; Claude Sonnet 4.6 (2026)</span>
+  <div id="goto-box">
+    <span id="goto-label">Fiber</span>
+    <input id="goto-input" type="number" placeholder="number" min="0" max="4999">
+    <button id="goto-btn">Go</button>
+  </div>
+</header>
+<main>
+  <div id="fp-wrap">
+    <canvas id="fp-canvas"></canvas>
+  </div>
+  <div id="plot-wrap">
+    <div id="fiber-title">← click a highlighted fiber</div>
+    <canvas id="plot-canvas"></canvas>
+    <div id="legend">
+      <div class="leg"><div class="lsw lsw-sv"></div>survey avg ± 1σ</div>
+      <div class="leg"><div class="lsw lsw-md"></div>model prediction</div>
+      <div class="leg"><div class="lsw" id="fb-swatch" style="background:#c03030"></div>fiber fail rate</div>
+    </div>
+    <div style="margin-top:8px">
+      <button class="save-btn" id="save-plot-btn">Save plot</button>
+    </div>
+  </div>
+</main>
+
+<script>
+const DATA         = __JSON__;
+const PETALS       = DATA.petals;
+const PETAL_COLORS = __COLORS__;
+
+
+const fpCanvas   = document.getElementById('fp-canvas');
+const fpCtx      = fpCanvas.getContext('2d');
+const plotCanvas = document.getElementById('plot-canvas');
+const plotCtx    = plotCanvas.getContext('2d');
+const tooltip    = document.getElementById('tooltip');
+const fiberTitle = document.getElementById('fiber-title');
+
+const FP_SIZE = Math.min(window.innerHeight - 80, 520);
+fpCanvas.width = fpCanvas.height = FP_SIZE;
+const SCALE = FP_SIZE / 900;
+const cx = FP_SIZE / 2, cy = FP_SIZE / 2;
+function mm2px(x, y) { return [cx + x * SCALE, cy - y * SCALE]; }
+
+const fibPos = {};
+for (const [fid, xy] of Object.entries(DATA.all_positions)) {
+  fibPos[fid] = mm2px(xy[0], xy[1]);
+}
+
+const activeFibers = Object.keys(DATA.fibers).map(Number);
+const badSet = new Set(activeFibers.filter(f => DATA.fibers[f].is_bad));
+
+// colour per fiber — all active fibers green, bad fibers orange
+function fiberColor(fib, hover, selected) {
+  if (selected)        return '#ffffff';
+  if (hover)           return '#ffffffcc';
+  if (badSet.has(fib)) return '#e8910a';
+  return '#4aaa6a';
+}
+
+let selectedFiber = null;
+let plotDots = [];   // [{x, y, mjd_lo, mjd_hi, fr}] for current time plot
+
+const MJD_EPOCH_MS = Date.UTC(1858, 10, 17);
+function mjdToDate(mjd) {
+  const d = new Date(MJD_EPOCH_MS + mjd * 86400000);
+  return d.toLocaleDateString('en-US', { month: 'short', year: 'numeric', timeZone: 'UTC' });
+}
+
+function drawFP(hoverId) {
+  const ctx = fpCtx;
+  ctx.clearRect(0, 0, FP_SIZE, FP_SIZE);
+  ctx.fillStyle = '#13131a';
+  ctx.fillRect(0, 0, FP_SIZE, FP_SIZE);
+
+  ctx.beginPath();
+  ctx.arc(cx, cy, 410 * SCALE, 0, 2 * Math.PI);
+  ctx.strokeStyle = 'rgba(255,255,255,.12)'; ctx.lineWidth = 0.8; ctx.stroke();
+
+  ctx.strokeStyle = 'rgba(255,255,255,.06)'; ctx.lineWidth = 0.6;
+  for (let p = 0; p < 10; p++) {
+    const ang = (p * 36) * Math.PI / 180;
+    ctx.beginPath();
+    ctx.moveTo(cx, cy);
+    ctx.lineTo(cx + 420 * SCALE * Math.cos(ang), cy - 420 * SCALE * Math.sin(ang));
+    ctx.stroke();
+  }
+
+  // background fibers
+  const activeSet = new Set(activeFibers.map(String));
+  ctx.fillStyle = '#2e2e3e';
+  for (const [fid, pos] of Object.entries(fibPos)) {
+    if (activeSet.has(fid)) continue;
+    ctx.beginPath(); ctx.arc(pos[0], pos[1], 1.5, 0, 2 * Math.PI); ctx.fill();
+  }
+
+  // active fibers
+  for (const fib of activeFibers) {
+    const pos = fibPos[fib];
+    if (!pos) continue;
+    const isSel = fib === selectedFiber;
+    const isHov = fib === hoverId;
+    const r = isSel ? 5 : (isHov ? 4 : (badSet.has(fib) ? 3 : 2.5));
+    ctx.beginPath(); ctx.arc(pos[0], pos[1], r, 0, 2 * Math.PI);
+    ctx.fillStyle = fiberColor(fib, isHov, isSel);
+    ctx.fill();
+  }
+}
+drawFP(null);
+
+function hitTest(mx, my) {
+  let best = null, bestD = 144;
+  for (const fib of activeFibers) {
+    const pos = fibPos[fib];
+    if (!pos) continue;
+    const dx = pos[0] - mx, dy = pos[1] - my;
+    const d2 = dx * dx + dy * dy;
+    if (d2 < bestD) { bestD = d2; best = fib; }
+  }
+  return best;
+}
+
+let lastHov = null;
+fpCanvas.addEventListener('mousemove', e => {
+  const r = fpCanvas.getBoundingClientRect();
+  const fib = hitTest(e.clientX - r.left, e.clientY - r.top);
+  if (fib !== lastHov) { lastHov = fib; drawFP(fib); }
+  if (fib !== null) {
+    const fd = DATA.fibers[fib];
+    const ns  = fd.nsig !== null ? '  σ = ' + fd.nsig.toFixed(1) : '';
+    const bad = fd.is_bad ? '  ★ BAD' : '';
+    tooltip.textContent   = 'fiber ' + fib + '  p' + fd.petal + '   n_obs = ' + fd.n_obs + ns + bad;
+    tooltip.style.left    = (e.clientX + 14) + 'px';
+    tooltip.style.top     = (e.clientY - 10) + 'px';
+    tooltip.style.opacity = '1';
+    fpCanvas.style.cursor = 'pointer';
+  } else {
+    tooltip.style.opacity = '0';
+    fpCanvas.style.cursor = 'crosshair';
+  }
+});
+fpCanvas.addEventListener('mouseleave', () => {
+  tooltip.style.opacity = '0'; lastHov = null; drawFP(null);
+});
+fpCanvas.addEventListener('click', e => {
+  const r = fpCanvas.getBoundingClientRect();
+  const fib = hitTest(e.clientX - r.left, e.clientY - r.top);
+  if (fib !== null) { selectedFiber = fib; drawFP(lastHov); drawTimePlot(fib); }
+});
+
+// ── go-to fiber box ───────────────────────────────────────────────────────────
+function goToFiber(val) {
+  const inp = document.getElementById('goto-input');
+  const fib = parseInt(val, 10);
+  if (isNaN(fib) || !DATA.fibers[fib]) {
+    inp.classList.add('error');
+    fiberTitle.innerHTML = '<span style="color:#c03030">fiber ' + fib + ' not in loaded petals</span>';
+    return;
+  }
+  inp.classList.remove('error');
+  selectedFiber = fib;
+  drawFP(null);
+  drawTimePlot(fib);
+}
+document.getElementById('goto-btn').addEventListener('click', () => {
+  goToFiber(document.getElementById('goto-input').value);
+});
+document.getElementById('goto-input').addEventListener('keydown', e => {
+  if (e.key === 'Enter') goToFiber(e.target.value);
+  e.target.classList.remove('error');
+});
+
+// ── plot canvas dot mouseover ─────────────────────────────────────────────────
+plotCanvas.addEventListener('mousemove', e => {
+  const r  = plotCanvas.getBoundingClientRect();
+  const mx = e.clientX - r.left, my = e.clientY - r.top;
+  let best = null, bestD = 12 * 12;
+  for (const dot of plotDots) {
+    const dx = dot.x - mx, dy = dot.y - my;
+    const d2 = dx * dx + dy * dy;
+    if (d2 < bestD) { bestD = d2; best = dot; }
+  }
+  if (best) {
+    tooltip.textContent = mjdToDate(best.mjd_lo) + ' – ' + mjdToDate(best.mjd_hi) +
+                          '   fail = ' + (best.fr * 100).toFixed(1) + '%';
+    tooltip.style.left    = (e.clientX + 14) + 'px';
+    tooltip.style.top     = (e.clientY - 10) + 'px';
+    tooltip.style.opacity = '1';
+    plotCanvas.style.cursor = 'crosshair';
+  } else {
+    tooltip.style.opacity   = '0';
+    plotCanvas.style.cursor = 'default';
+  }
+});
+plotCanvas.addEventListener('mouseleave', () => { tooltip.style.opacity = '0'; });
+
+// ── time plot ─────────────────────────────────────────────────────────────────
+function drawTimePlot(fib) {
+  const fd   = DATA.fibers[fib];
+  const wrap = document.getElementById('plot-wrap');
+  const W    = wrap.clientWidth - 32;
+  const H    = Math.min(Math.round(W * 0.52), 340);
+  plotCanvas.width = W; plotCanvas.height = H;
+
+  const ctx = plotCtx;
+  const PAD = { l: 52, r: 18, t: 18, b: 40 };
+  const pw = W - PAD.l - PAD.r, ph = H - PAD.t - PAD.b;
+
+  ctx.fillStyle = '#ffffff'; ctx.fillRect(0, 0, W, H);
+
+  const bins  = DATA.bins_mjd;
+  const sv_fr = DATA.survey_fr;
+  const sv_er = DATA.survey_er;
+  const fr    = fd.fr, er = fd.er, pred = fd.pred;
+
+  const xmin = bins[0], xmax = bins[bins.length - 1];
+  const xScale = v => PAD.l + (v - xmin) / (xmax - xmin) * pw;
+  const allY = [...fr, ...sv_fr, ...pred].filter(v => v !== null);
+  const ymax = allY.length ? Math.max(...allY) * 1.25 : 0.4;
+  const yScale = v => PAD.t + ph - (v / ymax) * ph;
+
+  const rawStep = ymax / 4;
+  const mag = Math.pow(10, Math.floor(Math.log10(rawStep)));
+  const step = [1, 2, 5].map(f => f * mag).find(s => s >= rawStep) || mag;
+  const yticks = [];
+  for (let v = step; v <= ymax * 1.05; v = Math.round((v + step) * 1e6) / 1e6) yticks.push(v);
+  ctx.strokeStyle = 'rgba(0,0,0,.08)'; ctx.lineWidth = 0.6;
+  for (const y of yticks) {
+    ctx.beginPath(); ctx.moveTo(PAD.l, yScale(y)); ctx.lineTo(PAD.l + pw, yScale(y)); ctx.stroke();
+  }
+
+  // survey avg fill + line
+  ctx.beginPath();
+  let first = true;
+  for (let i = 0; i < bins.length; i++) {
+    if (sv_fr[i] === null || sv_er[i] === null) { first = true; continue; }
+    first ? (ctx.moveTo(xScale(bins[i]), yScale(sv_fr[i] + sv_er[i])), first = false)
+          : ctx.lineTo(xScale(bins[i]), yScale(sv_fr[i] + sv_er[i]));
+  }
+  for (let i = bins.length - 1; i >= 0; i--) {
+    if (sv_fr[i] === null || sv_er[i] === null) continue;
+    ctx.lineTo(xScale(bins[i]), yScale(sv_fr[i] - sv_er[i]));
+  }
+  ctx.closePath(); ctx.fillStyle = 'rgba(180,180,210,.14)'; ctx.fill();
+  ctx.beginPath(); first = true;
+  for (let i = 0; i < bins.length; i++) {
+    if (sv_fr[i] === null) { first = true; continue; }
+    first ? (ctx.moveTo(xScale(bins[i]), yScale(sv_fr[i])), first = false)
+          : ctx.lineTo(xScale(bins[i]), yScale(sv_fr[i]));
+  }
+  ctx.strokeStyle = 'rgba(180,180,210,.4)'; ctx.lineWidth = 1; ctx.stroke();
+
+  // model prediction
+  ctx.beginPath(); first = true; ctx.setLineDash([4, 3]);
+  for (let i = 0; i < bins.length; i++) {
+    if (pred[i] === null) { first = true; continue; }
+    first ? (ctx.moveTo(xScale(bins[i]), yScale(pred[i])), first = false)
+          : ctx.lineTo(xScale(bins[i]), yScale(pred[i]));
+  }
+  ctx.strokeStyle = 'rgba(200,200,200,.6)'; ctx.lineWidth = 1.2; ctx.stroke();
+  ctx.setLineDash([]);
+
+  // year lines
+  ctx.strokeStyle = 'rgba(0,0,0,.10)'; ctx.lineWidth = 0.6;
+  ctx.fillStyle   = 'rgba(0,0,0,.35)';
+  ctx.font = '10px ui-monospace,Menlo,monospace'; ctx.textAlign = 'left';
+  for (let yr = 2021; yr <= 2026; yr++) {
+    const mjd = Math.round((Date.UTC(yr, 0, 1) - Date.UTC(1858, 10, 17)) / 86400000);
+    if (mjd < xmin || mjd > xmax) continue;
+    const x = xScale(mjd);
+    ctx.beginPath(); ctx.moveTo(x, PAD.t); ctx.lineTo(x, PAD.t + ph); ctx.stroke();
+    ctx.fillText(yr, x + 2, PAD.t + ph - 3);
+  }
+
+  // time plot always red
+  const fcolor = '#c03030';
+  document.getElementById('fb-swatch').style.background = fcolor;
+
+  // fail rate line
+  ctx.beginPath(); first = true;
+  for (let i = 0; i < bins.length; i++) {
+    if (fr[i] === null) { first = true; continue; }
+    first ? (ctx.moveTo(xScale(bins[i]), yScale(fr[i])), first = false)
+          : ctx.lineTo(xScale(bins[i]), yScale(fr[i]));
+  }
+  ctx.strokeStyle = fcolor + '99'; ctx.lineWidth = 1; ctx.stroke();
+
+  // error bars + dots
+  const binW = bins.length > 1 ? (bins[1] - bins[0]) : 0;
+  plotDots = [];
+  for (let i = 0; i < bins.length; i++) {
+    if (fr[i] === null) continue;
+    const x = xScale(bins[i]), y = yScale(fr[i]);
+    const ey = er[i] !== null ? (er[i] / ymax) * ph : 0;
+    ctx.strokeStyle = fcolor + '88'; ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(x, y - ey); ctx.lineTo(x, y + ey);
+    ctx.moveTo(x - 2, y - ey); ctx.lineTo(x + 2, y - ey);
+    ctx.moveTo(x - 2, y + ey); ctx.lineTo(x + 2, y + ey);
+    ctx.stroke();
+    ctx.beginPath(); ctx.arc(x, y, 2.8, 0, 2 * Math.PI);
+    ctx.fillStyle = fcolor; ctx.fill();
+    plotDots.push({ x, y, mjd_lo: bins[i] - binW/2, mjd_hi: bins[i] + binW/2, fr: fr[i] });
+  }
+
+  // axes
+  ctx.strokeStyle = 'rgba(0,0,0,.4)'; ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(PAD.l, PAD.t); ctx.lineTo(PAD.l, PAD.t + ph); ctx.lineTo(PAD.l + pw, PAD.t + ph);
+  ctx.stroke();
+  ctx.fillStyle = 'rgba(0,0,0,.7)'; ctx.textAlign = 'right';
+  for (const y of yticks) {
+    const py = yScale(y);
+    ctx.beginPath(); ctx.moveTo(PAD.l - 3, py); ctx.lineTo(PAD.l, py);
+    ctx.strokeStyle = 'rgba(0,0,0,.4)'; ctx.lineWidth = 1; ctx.stroke();
+    ctx.fillText(y.toFixed(2), PAD.l - 6, py + 3.5);
+  }
+  ctx.textAlign = 'center'; ctx.fillStyle = 'rgba(0,0,0,.4)';
+  ctx.fillText('MJD', PAD.l + pw / 2, H - 8);
+
+  const ns        = fd.nsig !== null ? '   σ = ' + fd.nsig.toFixed(1) : '';
+  const bad       = fd.is_bad ? '   ★ BAD' : '';
+  const titleColor = fd.is_bad ? '#e8910a' : '#e0e0f0';
+  fiberTitle.innerHTML =
+    '<span style="color:' + titleColor + '">fiber ' + fib +
+    ' &nbsp;·&nbsp; petal ' + fd.petal +
+    ' &nbsp;·&nbsp; n_obs = ' + fd.n_obs + ns + bad + '</span>';
+}
+
+const overlay     = document.getElementById('img-overlay');
+const overlayImg  = document.getElementById('img-overlay-img');
+document.getElementById('img-overlay-close').addEventListener('click', () => overlay.classList.remove('show'));
+overlay.addEventListener('click', e => { if (e.target === overlay) overlay.classList.remove('show'); });
+
+function showCanvasOverlay(canvas) {
+  overlayImg.src = canvas.toDataURL('image/png');
+  overlay.classList.add('show');
+}
+
+document.getElementById('save-plot-btn').addEventListener('click', () => showCanvasOverlay(plotCanvas));
+</script>
+"""
+
+colors_js = json.dumps([PETAL_COLORS[i % len(PETAL_COLORS)] for i in range(len(PETALS))])
+html = HTML.replace('__JSON__', raw_json) \
+           .replace('__LABEL__', label) \
+           .replace('__COLORS__', colors_js)
+
+with open(out_path, 'w') as f:
+    f.write(html)
+print(f'Saved {out_path}  ({os.path.getsize(out_path)//1024} KB)', flush=True)

--- a/scripts/validation/badfiber_time/make_petal_focal_data.py
+++ b/scripts/validation/badfiber_time/make_petal_focal_data.py
@@ -1,0 +1,145 @@
+"""
+make_petal_focal_data.py
+Extract all data needed for the interactive focal-plane viewer for one petal.
+Outputs: lrg_petal{N}_focal_data.json
+
+JSON structure:
+{
+  "petal": 0,
+  "bins_mjd": [32 bin-centre MJDs],
+  "survey_fr": [32 floats],   -- survey-average fail rate
+  "survey_er": [32 floats],
+  "fibers": {
+    "0": { "x": float, "y": float, "is_bad": bool,
+           "nsig": float|null, "n_obs": int,
+           "fr": [32], "er": [32], "pred": [32] },
+    ...
+  }
+}
+
+Usage:
+  python make_petal_focal_data.py             # petal 0
+  python make_petal_focal_data.py --petal 7
+"""
+
+import argparse, json, os
+import numpy as np
+import fitsio
+from scipy import special
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--petal', type=int, default=0)
+args = parser.parse_args()
+PETAL = args.petal
+
+DATADIR = '/global/u1/r/rohlf/bao_jr/dr3-matterhorn-checks/all-fibers-vs-time'
+LRGCAT  = '/global/cfs/cdirs/desi/survey/catalogs/DA3/LSS/matterhorn-v2/LSScats/test/LRG_full_noveto.dat.fits'
+BADFIB  = '/global/u1/r/rohlf/bao_jr/dr3-matterhorn-checks/krolewski-pipeline/badfibers/LRG_badfibers.txt'
+SUMFILE = '/global/u1/r/rohlf/bao_jr/dr3-matterhorn-checks/krolewski-pipeline/summaryscale/LRGfibersim_matterhorn-v2.txt'
+NBINS   = 32
+
+bad_fibers = set(np.loadtxt(BADFIB, dtype=int).tolist())
+
+nsig_map = {}
+try:
+    data = np.loadtxt(SUMFILE, usecols=range(10))
+    for row in data:
+        fib = int(row[0])
+        pval = float(row[1])
+        nsig_map[fib] = float(-np.sqrt(2) * special.erfcinv(2 * np.clip(pval, 1e-10, 1-1e-10)))
+except Exception as e:
+    print(f'nsig load failed: {e}')
+
+# ── focal plane positions (median per fiber from LRG catalog) ─────────────────
+print('Reading focal plane positions...', flush=True)
+cat_fp = fitsio.read(LRGCAT, columns=['FIBER', 'FIBERASSIGN_X', 'FIBERASSIGN_Y'])
+fp_fiber = np.array(cat_fp['FIBER'],         dtype=np.int32)
+fp_x     = np.array(cat_fp['FIBERASSIGN_X'], dtype=np.float32)
+fp_y     = np.array(cat_fp['FIBERASSIGN_Y'], dtype=np.float32)
+valid    = (fp_fiber >= 0) & (fp_fiber < 5000) & (fp_x != 999999)
+
+fiber_x = np.full(5000, np.nan)
+fiber_y = np.full(5000, np.nan)
+fib_lo, fib_hi = PETAL * 500, (PETAL + 1) * 500
+for fib in range(5000):
+    m = valid & (fp_fiber == fib)
+    if m.any():
+        fiber_x[fib] = float(np.median(fp_x[m]))
+        fiber_y[fib] = float(np.median(fp_y[m]))
+print(f'  {np.isfinite(fiber_x).sum()} / 5000 total fibers with positions', flush=True)
+print(f'  {np.isfinite(fiber_x[fib_lo:fib_hi]).sum()} / 500 petal {PETAL} fibers with positions', flush=True)
+
+# ── load NPZ ──────────────────────────────────────────────────────────────────
+print('Loading LRG NPZ...', flush=True)
+d = np.load(f'{DATADIR}/LRG_fiber_time.npz')
+all_mjd  = d['mjd'].astype(np.float64)
+all_fail = (~d['zsuc']).astype(np.float64)
+all_mod  = d['mod_success_rate'].astype(np.float64)
+
+bins = np.linspace(all_mjd.min(), all_mjd.max(), NBINS + 1)
+bcs  = 0.5 * (bins[:-1] + bins[1:])
+
+n_tot_sv  = np.histogram(all_mjd, bins=bins)[0].astype(np.float64)
+n_fail_sv = np.histogram(all_mjd, bins=bins, weights=all_fail)[0]
+with np.errstate(invalid='ignore', divide='ignore'):
+    sv_fr = np.where(n_tot_sv >= 10, n_fail_sv / n_tot_sv, np.nan)
+sv_er = np.where(np.isfinite(sv_fr),
+                 np.sqrt(sv_fr * (1 - sv_fr) / np.maximum(n_tot_sv, 1)), np.nan)
+
+scale = (1 - all_fail.mean()) / all_mod.mean()
+print(f'  scale={scale:.4f}', flush=True)
+
+def get_fiber(fib):
+    s, e = d['index'][fib]
+    if s < 0:
+        return np.array([]), np.array([], dtype=bool), np.array([])
+    return d['mjd'][s:e], d['zsuc'][s:e], d['mod_success_rate'][s:e]
+
+def binned(mjds, sucs, mods):
+    fr, er, pred = [], [], []
+    for b0, b1 in zip(bins[:-1], bins[1:]):
+        m = (mjds >= b0) & (mjds < b1)
+        n = m.sum()
+        if n < 3:
+            fr.append(None); er.append(None); pred.append(None)
+        else:
+            f = float((~sucs[m]).sum() / n)
+            fr.append(round(f, 6))
+            er.append(round(float(np.sqrt(f * (1 - f) / n)), 6))
+            pred.append(round(float(1 - np.clip(mods[m] * scale, 0, 1).mean()), 6))
+    return fr, er, pred
+
+# ── build output dict ─────────────────────────────────────────────────────────
+all_pos = {}
+for fib in range(5000):
+    if np.isfinite(fiber_x[fib]):
+        all_pos[str(fib)] = [round(fiber_x[fib], 1), round(fiber_y[fib], 1)]
+
+out = {
+    'petal': PETAL,
+    'all_positions': all_pos,
+    'bins_mjd': [round(float(v), 2) for v in bcs],
+    'survey_fr': [round(float(v), 6) if np.isfinite(v) else None for v in sv_fr],
+    'survey_er': [round(float(v), 6) if np.isfinite(v) else None for v in sv_er],
+    'fibers': {}
+}
+
+print(f'Computing binned rates for petal {PETAL} fibers...', flush=True)
+for fib in range(fib_lo, fib_hi):
+    mjds, sucs, mods = get_fiber(fib)
+    fr, er, pred = binned(mjds, sucs, mods) if len(mjds) >= 5 else ([None]*NBINS, [None]*NBINS, [None]*NBINS)
+    out['fibers'][str(fib)] = {
+        'x':      round(fiber_x[fib], 2) if np.isfinite(fiber_x[fib]) else None,
+        'y':      round(fiber_y[fib], 2) if np.isfinite(fiber_y[fib]) else None,
+        'is_bad': fib in bad_fibers,
+        'nsig':   round(nsig_map[fib], 2) if fib in nsig_map else None,
+        'n_obs':  int(len(mjds)),
+        'fr':     fr,
+        'er':     er,
+        'pred':   pred,
+    }
+
+outpath = f'{DATADIR}/lrg_petal{PETAL}_focal_data.json'
+with open(outpath, 'w') as f:
+    json.dump(out, f, separators=(',', ':'))
+print(f'Saved {outpath}  ({os.path.getsize(outpath)//1024} KB)', flush=True)

--- a/scripts/validation/badfiber_time/plot_petal_mosaic.py
+++ b/scripts/validation/badfiber_time/plot_petal_mosaic.py
@@ -1,0 +1,197 @@
+"""
+plot_petal_mosaic.py
+Mosaic of LRG failure-rate vs time for every fiber in one petal.
+Layout: N_COLS x N_ROWS panels (default 5 x 100 = all 500 fibers in a petal).
+Bad fibers (Krolewski nsig <= -4) are highlighted with a red panel title.
+Shows fiber fail rate, survey average (light gray), and model prediction
+(dark gray dashed).  CCD swap dates overlaid per petal.
+
+Usage:
+  python plot_petal_mosaic.py            # petal 0
+  python plot_petal_mosaic.py --petal 7  # petal 7
+"""
+
+import argparse
+import numpy as np
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import datetime
+from scipy import special
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--petal', type=int, default=0)
+args = parser.parse_args()
+PETAL = args.petal
+
+DATADIR = '/global/u1/r/rohlf/bao_jr/dr3-matterhorn-checks/all-fibers-vs-time'
+BADFIB  = '/global/u1/r/rohlf/bao_jr/dr3-matterhorn-checks/krolewski-pipeline/badfibers/LRG_badfibers.txt'
+SUMFILE = '/global/u1/r/rohlf/bao_jr/dr3-matterhorn-checks/krolewski-pipeline/summaryscale/LRGfibersim_matterhorn-v2.txt'
+NBINS   = 32
+N_COLS  = 5
+N_ROWS  = 100   # 5 x 100 = 500 fibers per petal
+
+MJD_EPOCH = datetime.date(1858, 11, 17)
+
+def date_to_mjd(yyyymmdd):
+    s = str(yyyymmdd)
+    d = datetime.date(int(s[:4]), int(s[4:6]), int(s[6:8]))
+    return (d - MJD_EPOCH).days
+
+CCD_SWAPS_ALL = {
+    0: [(date_to_mjd(20260106), 'r')],
+    1: [(date_to_mjd(20220613), 'b'), (date_to_mjd(20230727), 'b'),
+        (date_to_mjd(20231129), 'z'), (date_to_mjd(20241119), 'r')],
+    2: [(date_to_mjd(20201113), 'r')],
+    3: [(date_to_mjd(20250514), 'z')],
+    4: [(date_to_mjd(20221108), 'b'), (date_to_mjd(20221108), 'r')],
+    5: [(date_to_mjd(20210622), 'b'), (date_to_mjd(20221108), 'z')],
+    6: [],
+    7: [(date_to_mjd(20240724), 'r'), (date_to_mjd(20251007), 'r'),
+        (date_to_mjd(20251007), 'z')],
+    8: [(date_to_mjd(20230507), 'b')],
+    9: [(date_to_mjd(20210615), 'r'), (date_to_mjd(20260429), 'r')],
+}
+CHAN_COLOR = {'b': 'royalblue', 'r': 'crimson', 'z': 'darkorchid'}
+MJD_YEAR = {yr: (datetime.date(yr, 1, 1) - MJD_EPOCH).days for yr in range(2020, 2027)}
+
+# ── bad fiber set and nsig map ─────────────────────────────────────────────────
+bad_fibers = set(np.loadtxt(BADFIB, dtype=int).tolist())
+nsig_map = {}
+try:
+    data = np.loadtxt(SUMFILE, usecols=range(10))
+    for row in data:
+        fib = int(row[0])
+        pval = float(row[1])
+        nsig_map[fib] = -np.sqrt(2) * special.erfcinv(2 * np.clip(pval, 1e-10, 1-1e-10))
+except Exception as e:
+    print(f'nsig load failed: {e}')
+
+# ── load NPZ ───────────────────────────────────────────────────────────────────
+print('Loading LRG NPZ...', flush=True)
+d = np.load(f'{DATADIR}/LRG_fiber_time.npz')
+all_mjd  = d['mjd'].astype(np.float64)
+all_fail = (~d['zsuc']).astype(np.float64)
+all_mod  = d['mod_success_rate'].astype(np.float64)
+
+bins = np.linspace(all_mjd.min(), all_mjd.max(), NBINS + 1)
+bcs  = 0.5 * (bins[:-1] + bins[1:])
+
+# survey average across all fibers
+n_tot_sv  = np.histogram(all_mjd, bins=bins)[0].astype(np.float64)
+n_fail_sv = np.histogram(all_mjd, bins=bins, weights=all_fail)[0]
+with np.errstate(invalid='ignore', divide='ignore'):
+    sv_fr = np.where(n_tot_sv >= 10, n_fail_sv / n_tot_sv, np.nan)
+sv_er = np.where(np.isfinite(sv_fr),
+                 np.sqrt(sv_fr * (1 - sv_fr) / np.maximum(n_tot_sv, 1)), np.nan)
+
+scale = (1 - all_fail.mean()) / all_mod.mean()
+print(f'  scale={scale:.4f}', flush=True)
+
+def get_fiber(fib):
+    s, e = d['index'][fib]
+    if s < 0:
+        return np.array([]), np.array([], dtype=bool), np.array([])
+    return d['mjd'][s:e], d['zsuc'][s:e], d['mod_success_rate'][s:e]
+
+def binned_failrate(mjds, sucs):
+    fr, er = [], []
+    for b0, b1 in zip(bins[:-1], bins[1:]):
+        m = (mjds >= b0) & (mjds < b1)
+        n = m.sum()
+        if n < 3:
+            fr.append(np.nan); er.append(np.nan)
+        else:
+            f = (~sucs[m]).sum() / n
+            fr.append(f)
+            er.append(np.sqrt(f * (1 - f) / n))
+    return np.array(fr), np.array(er)
+
+def model_pred(mjds, mods):
+    pred = np.full(len(bcs), np.nan)
+    for i, (b0, b1) in enumerate(zip(bins[:-1], bins[1:])):
+        m = (mjds >= b0) & (mjds < b1)
+        if m.sum() >= 3:
+            pred[i] = 1 - np.clip(mods[m] * scale, 0, 1).mean()
+    return pred
+
+# ── fibers in this petal ───────────────────────────────────────────────────────
+fibers = list(range(PETAL * 500, (PETAL + 1) * 500))
+print(f'Petal {PETAL}: fibers {fibers[0]}–{fibers[-1]}  ({len(fibers)} total)', flush=True)
+
+# ── figure ────────────────────────────────────────────────────────────────────
+fig, axes = plt.subplots(N_ROWS, N_COLS,
+                         figsize=(N_COLS * 2.5, N_ROWS * 2.0),
+                         squeeze=False, sharex=True)
+fig.suptitle(f'LRG petal {PETAL} — all {len(fibers)} fibers — failure rate vs time  (matterhorn-v2)\n'
+             'Red: fiber  |  Light gray: survey avg  |  Dark dashed: model prediction  |  '
+             'Red title = Krolewski bad fiber',
+             fontsize=10, y=1.002)
+
+for fi, fib in enumerate(fibers):
+    ax    = axes[fi // N_COLS, fi % N_COLS]
+    mjds, sucs, mods = get_fiber(fib)
+
+    ns     = nsig_map.get(fib, np.nan)
+    ns_str = f' σ={ns:.1f}' if np.isfinite(ns) else ''
+    is_bad = fib in bad_fibers
+    title_color = 'darkorange' if is_bad else 'black'
+    ax.set_title(f'fib {fib}{ns_str}', fontsize=5, pad=2, color=title_color,
+                 fontweight='bold' if is_bad else 'normal')
+
+    if len(mjds) < 5:
+        ax.text(0.5, 0.5, 'no data', ha='center', va='center',
+                transform=ax.transAxes, fontsize=5, color='gray')
+        ax.tick_params(labelsize=4)
+        continue
+
+    fr, er = binned_failrate(mjds, sucs)
+    pred   = model_pred(mjds, mods)
+    ok     = np.isfinite(fr)
+    sv_ok  = np.isfinite(sv_fr) & ok
+    pr_ok  = np.isfinite(pred) & ok
+
+    ax.fill_between(bcs[sv_ok],
+                    (sv_fr - sv_er)[sv_ok], (sv_fr + sv_er)[sv_ok],
+                    color='black', alpha=0.10, zorder=0)
+    ax.plot(bcs[sv_ok], sv_fr[sv_ok], color='black', lw=0.5, alpha=0.25)
+    ax.plot(bcs[pr_ok], pred[pr_ok], color='black', lw=0.8,
+            linestyle='--', alpha=0.55)
+    ax.errorbar(bcs[ok], fr[ok], yerr=er[ok],
+                fmt='o-', color='firebrick', ms=1.8, lw=0.9,
+                capsize=1.0, elinewidth=0.5)
+
+    ax.set_ylim(bottom=0)
+    ax.tick_params(labelsize=4)
+    ax.set_ylabel('fail', fontsize=4)
+
+    vmin, vmax = mjds.min(), mjds.max()
+    for yr, mjd_yr in MJD_YEAR.items():
+        if vmin < mjd_yr < vmax:
+            ax.axvline(mjd_yr, color='lightgray', lw=0.3, linestyle=':')
+    for mjd_swap, ch in CCD_SWAPS_ALL.get(PETAL, []):
+        if vmin < mjd_swap < vmax:
+            ax.axvline(mjd_swap, color=CHAN_COLOR[ch], lw=0.7,
+                       linestyle='--', alpha=0.8)
+
+# top-row year labels
+monthly = [(datetime.date(yr, mo, 1) - MJD_EPOCH).days
+           for yr in range(2020, 2027) for mo in range(1, 13)]
+yearly  = [(datetime.date(yr,  1, 1) - MJD_EPOCH).days for yr in range(2020, 2027)]
+for col in range(N_COLS):
+    ax2 = axes[0, col].twiny()
+    ax2.set_xlim(bins[0], bins[-1])
+    ax2.set_xticks(yearly)
+    ax2.set_xticklabels([str(y) for y in range(2020, 2027)], fontsize=4)
+    ax2.tick_params(axis='x', which='major', direction='in', length=6)
+    ax2.set_xticks(monthly, minor=True)
+    ax2.tick_params(axis='x', which='minor', direction='in', length=2)
+
+plt.tight_layout()
+outpng = f'{DATADIR}/lrg_petal{PETAL}_mosaic.png'
+outpdf = f'{DATADIR}/lrg_petal{PETAL}_mosaic.pdf'
+fig.savefig(outpng, dpi=100, bbox_inches='tight')
+fig.savefig(outpdf, bbox_inches='tight')
+plt.close(fig)
+print(f'Saved {outpng}', flush=True)
+print(f'Saved {outpdf}', flush=True)


### PR DESCRIPTION
…c scripts

Add three new scripts for LRG fiber quality visualization (matterhorn-v2):
- make_petal_focal_data.py: extracts per-petal time series + focal plane positions into a self-contained JSON (~470 KB per petal)
- make_focal_viewer_multi.py: builds a fully self-contained interactive HTML focal plane viewer; hover shows fiber info, click shows failure rate vs time plot, orange dots mark Krolewski bad fibers (nsig <= -4)
- plot_petal_mosaic.py: generates 5x100 mosaic of all 500 fibers in a petal with PNG and PDF output; bad fiber titles highlighted in orange

Update README with build instructions and output file descriptions.