### PR TITLE
Fix ntile info retrieval in the subsample script

### DIFF
--- a/scripts/combine_BGS_BRIGHT_FAINT.py
+++ b/scripts/combine_BGS_BRIGHT_FAINT.py
@@ -1,6 +1,8 @@
 import numpy as np
 from astropy.table import Table, vstack
-from LSS.common_tools import write_LSS_scratchcp
+import fitsio
+from LSS.common_tools import write_LSS_scratchcp, splitGC
+from LSS.globals import main
 from pycorr import setup_logging
 import logging
 import argparse
@@ -35,6 +37,8 @@ output_dir: str = args.outdir + '/'
 logger.info(f"Output directory is {output_dir}")
 input_dir_main = os.path.join(args.basedir, args.survey, 'LSS', args.verspec, 'LSScats', args.version, 'nonKP') + '/' # basedir with LSS to find the non-cut catalogs, and for fallback if the cut catalogs are not found in the analysis directory
 logger.info(f"Input directory for non-cut catalogs (and fallback) is {input_dir_main}")
+input_dir_main_full = os.path.join(args.basedir, args.survey, 'LSS', args.verspec, 'LSScats', args.version, 'nonKP') + '/' # basedir with LSS to find the non-cut catalogs, and for fallback if the cut catalogs are not found in the analysis directory
+logger.info(f"Input directory for non-cut full catalogs (if they are needed) is {input_dir_main_full}")
 try_dirs = [input_dir, output_dir, input_dir_main] # order to look for input files
 
 samples_base = ['BRIGHT', 'FAINT']
@@ -86,8 +90,28 @@ for (sample, sample_base) in zip(samples, samples_base):
         logger.info(f"Reading nz data for sample {sample} and region {reg} from {nz_name}")
         nz_data[sample][reg] = np.loadtxt(nz_name).T
         logger.info(f"Obtaining NTILE data for sample {sample_base} and region {reg}")
-        base_data = Table.read(input_dir_main + f'BGS_{sample_base}_{reg}_clustering.dat.fits') # the base sample catalog should be in the main input dir
-        comp_ntl = np.bincount(base_data['NTILE']-1) / np.bincount(base_data['NTILE']-1, weights=base_data['WEIGHT_COMP']) # inverse of the mean completeness weight in data for each NTILE value (note that it is shifted down by 1)
+        base_clustering_data_fname = input_dir_main + f'BGS_{sample_base}_{reg}_clustering.dat.fits' # the base sample catalog should be in the main input dir
+        if os.path.isfile(base_clustering_data_fname): # use it
+            base_data = fitsio.read(base_clustering_data_fname, columns=['NTILE', 'WEIGHT_COMP', 'FRAC_TLOBS_TILES'])
+            comp_ntl = np.bincount(base_data['NTILE']-1) / np.bincount(base_data['NTILE']-1, weights=base_data['WEIGHT_COMP']) # inverse of the mean completeness weight in data for each NTILE value (note that it is shifted down by 1)
+        else: # use the full catalog to get the NTILE info (particularly for DR3), need extra steps for compatibility with the clustering catalog
+            base_data = fitsio.read(input_dir_main_full + f'BGS_{sample_base}_full_HPmapcut.dat.fits', columns=['RA', 'DEC', 'NTILE', 'ZWARN', 'DELTACHI2', 'FRACZ_TILELOCID', 'FRAC_TLOBS_TILES'])
+            # select region (NGC/SGC)
+            sel = splitGC(base_data)
+            if reg == 'SGC': sel = ~sel
+            base_data = base_data[sel]
+            del sel
+            # define "good z" cuts from the full catalog to the clustering catalog in accordance with the mkclusdat function for BGS
+            wz = base_data['ZWARN'] == 0
+            wz &= base_data['ZWARN']*0 == 0
+            wz &= base_data['ZWARN'] != 999999
+            dchi2 = main(args.input_tracer,args.verspec,survey=args.survey).dchi2
+            if dchi2 is not None:
+                wz &= base_data['DELTACHI2'] > dchi2
+            base_data = base_data[wz] # apply the "good z" cut to get the same objects as in the clustering catalog
+            del wz
+            # now should match the clustering catalog
+            comp_ntl = np.bincount(base_data['NTILE']-1) / np.bincount(base_data['NTILE']-1, weights=1/base_data['FRACZ_TILELOCID']) # inverse of the mean completeness weight in data for each NTILE value (note that it is shifted down by 1)
         fttl = np.bincount(base_data['NTILE']-1, weights=base_data['FRAC_TLOBS_TILES']) / np.bincount(base_data['NTILE']-1) # mean of FRAC_TLOBS_TILES for each (positive integer) NTILE in data (randoms might be more correct for this; note that NTILE is shifted down by 1)
         comp_ntile_factors[sample][reg] = comp_ntl * fttl # indexed by NTILE-1
         del base_data # free memory

--- a/scripts/combine_BGS_BRIGHT_FAINT.py
+++ b/scripts/combine_BGS_BRIGHT_FAINT.py
@@ -105,7 +105,7 @@ for (sample, sample_base) in zip(samples, samples_base):
             wz = base_data['ZWARN'] == 0
             wz &= base_data['ZWARN']*0 == 0
             wz &= base_data['ZWARN'] != 999999
-            dchi2 = main(args.input_tracer,args.verspec,survey=args.survey).dchi2
+            dchi2 = main('BGS_' + sample_base, args.verspec, survey=args.survey).dchi2
             if dchi2 is not None:
                 wz &= base_data['DELTACHI2'] > dchi2
             base_data = base_data[wz] # apply the "good z" cut to get the same objects as in the clustering catalog

--- a/scripts/combine_BGS_BRIGHT_FAINT.py
+++ b/scripts/combine_BGS_BRIGHT_FAINT.py
@@ -86,7 +86,7 @@ for (sample, sample_base) in zip(samples, samples_base):
     nz_data[sample] = {}
     comp_ntile_factors[sample] = {}
     for reg in regions:
-        nz_name = lookup_dirs(f'BGS_{sample}_{reg}_nz.txt')
+        nz_name = lookup_dirs(f'BGS_{sample}_{reg}_nz.txt') # in principle, the nz file may be found in a different (earlier) directory than the clustering catalog(s), which would be somewhat inconsistent, but it does not seem very likely and may not be a problem if it happens
         logger.info(f"Reading nz data for sample {sample} and region {reg} from {nz_name}")
         nz_data[sample][reg] = np.loadtxt(nz_name).T
         logger.info(f"Obtaining NTILE data for sample {sample_base} and region {reg}")

--- a/scripts/combine_BGS_BRIGHT_FAINT.py
+++ b/scripts/combine_BGS_BRIGHT_FAINT.py
@@ -62,7 +62,7 @@ def read_catalog(sample: str, reg: str, iran: int | None = None) -> Table:
     basename = f'BGS_{sample}_{reg}' + f'_{iran}' * (iran is not None) + '_clustering.' + ('dat' if iran is None else 'ran') + '.fits'
     path = lookup_dirs(basename)
     logger.info(f"Reading clustering catalog from {path}")
-    return Table.read(path)
+    return Table(fitsio.read(path))
 
 
 def combine_regions(reg_cat_dict: dict[str, Table]) -> Table:

--- a/scripts/combine_BGS_BRIGHT_FAINT.py
+++ b/scripts/combine_BGS_BRIGHT_FAINT.py
@@ -31,13 +31,13 @@ parser.add_argument("--par", choices=['y', 'n'], help="run different random numb
 args = parser.parse_args()
 logger.info(f"Running with arguments: {args}")
 
-input_dir = os.path.join(args.basedir, args.survey, 'analysis', args.verspec, 'LSScats', args.version, 'nonKP') + '/' # basedir with analysis, where we keep non-standard catalogsS
+input_dir = os.path.join(args.basedir, args.survey, 'analysis', args.verspec, 'LSScats', args.version, 'nonKP') + '/' # basedir with analysis, where we keep non-standard clustering catalogs
 logger.info(f"Primary input directory is {input_dir}")
 output_dir: str = args.outdir + '/'
 logger.info(f"Output directory is {output_dir}")
-input_dir_main = os.path.join(args.basedir, args.survey, 'LSS', args.verspec, 'LSScats', args.version, 'nonKP') + '/' # basedir with LSS to find the non-cut catalogs, and for fallback if the cut catalogs are not found in the analysis directory
+input_dir_main = os.path.join(args.basedir, args.survey, 'LSS', args.verspec, 'LSScats', args.version, 'nonKP') + '/' # basedir with LSS to find the non-cut clustering catalogs, and for fallback if the cut clustering catalogs are not found in the analysis directory
 logger.info(f"Input directory for non-cut catalogs (and fallback) is {input_dir_main}")
-input_dir_main_full = os.path.join(args.basedir, args.survey, 'LSS', args.verspec, 'LSScats', args.version, 'nonKP') + '/' # basedir with LSS to find the non-cut catalogs, and for fallback if the cut catalogs are not found in the analysis directory
+input_dir_main_full = os.path.join(args.basedir, args.survey, 'LSS', args.verspec, 'LSScats', args.version) + '/' # basedir with LSS to find the non-cut full catalogs if needed (for DR3, the non-cut clustering catalogs are not made)
 logger.info(f"Input directory for non-cut full catalogs (if they are needed) is {input_dir_main_full}")
 try_dirs = [input_dir, output_dir, input_dir_main] # order to look for input files
 

--- a/scripts/mkCat_subsamp.py
+++ b/scripts/mkCat_subsamp.py
@@ -439,7 +439,8 @@ if args.nz == 'y':
 # this is new for doing after the fact based on clustering catalogs
 if args.imsys_clus == 'y':
     #import package
-    from LSS.imaging import densvar 
+    from LSS.imaging import densvar
+    import numpy.lib.recfunctions as rfn
     
     #setup redshift bins to use for regressions; you might find something else works better!
     if args.input_tracer[:3] == 'ELG':
@@ -482,9 +483,11 @@ if args.imsys_clus == 'y':
     #get randoms
     ranl = []
     for i in range(0,args.nran4imsys):
-        ran = fitsio.read(os.path.join(dirout, tracer_out+'_NGC_'+str(i)+'_clustering.ran.fits')) 
+        ran = fitsio.read(os.path.join(dirout, tracer_out+'_NGC_'+str(i)+'_clustering.ran.fits'))
+        ran = rfn.drop_fields(ran, 'WEIGHT_IMLIN_CLUS', asrecarray=True) # drop the column if it exists - it breaks the concatenation of the randoms if some have it and some don't
         ranl.append(ran)
-        ran = fitsio.read(os.path.join(dirout, tracer_out+'_SGC_'+str(i)+'_clustering.ran.fits')) 
+        ran = fitsio.read(os.path.join(dirout, tracer_out+'_SGC_'+str(i)+'_clustering.ran.fits'))
+        ran = rfn.drop_fields(ran, 'WEIGHT_IMLIN_CLUS', asrecarray=True) # drop the column if it exists - it breaks the concatenation of the randoms if some have it and some don't
         ranl.append(ran)
     rands = np.concatenate(ranl)
     

--- a/scripts/mkCat_subsamp.py
+++ b/scripts/mkCat_subsamp.py
@@ -354,6 +354,66 @@ def get_ntile_info(clus_orig_fname):
         fttl = np.bincount(fd['NTILE']-1, weights=fd['FRAC_TLOBS_TILES']) / np.bincount(fd['NTILE']-1) # mean of FRAC_TLOBS_TILES for each (positive integer) NTILE in data (although shouldn't this be computed in randoms?). Note that the NTILE values are shifted down by 1 to avoid guaranteed division by zero for NTILE=0
         comp_ntl *= fttl # if not using altmtl, also multiply by the mean FRAC_TLOBS_TILES for each NTILE to get the completeness. Both are indexed by NTILE-1
     return comp_ntl, weight_ntl # both are indexed by NTILE-1 as common.addnbar expects
+
+def get_ntile_info_from_full(full_orig_fname, tp, reg, ismock=False):
+    columns = ['RA', 'DEC', 'NTILE']
+    if tp[:3] == 'QSO': columns += ['Z', 'ZWARN']
+    if tp[:3] == 'ELG': columns += ['ZWARN', 'o2c', 'LOCATION_ASSIGNED']
+    if tp[:3] == 'LRG' or tp[:3] == 'LGE': columns += ['Z', 'ZWARN', 'DELTACHI2']
+    if tp[:3] == 'BGS': columns += ['ZWARN', 'DELTACHI2']
+    if ismock: columns += ['TARGETID']
+    columns += ['FRACZ_TILELOCID', 'FRAC_TLOBS_TILES'] if weightileloc else ['PROB_OBS']
+    ff = fitsio.read(full_orig_fname, columns=columns)
+    # select region (NGC/SGC)
+    sel = common.splitGC(ff)
+    if reg == 'SGC': sel = ~sel
+    ff = ff[sel]
+    del sel
+    # define "good z" cuts from the full catalog to the clustering catalog, based on the tracer type, in accordance with the mkclusdat function
+    if tp[:3] == 'QSO':
+        #good redshifts are currently just the ones that should have been defined in the QSO file when merged in full
+        wz = ff['Z']*0 == 0
+        wz &= ff['Z'] != 999999
+        wz &= ff['Z'] != 1.e20
+        wz &= ff['ZWARN'] != 999999
+        if ismock:
+            wz &= ff['TARGETID'] < 419430400000000
+    if tp[:3] == 'ELG':
+        wz = ff['ZWARN']*0 == 0
+        wz &= ff['ZWARN'] != 999999
+        if dchi2 is not None:
+            wz &= ff['o2c'] > dchi2
+        wz &= ff['LOCATION_ASSIGNED'] == 1
+        if ismock:
+            wz &= ff['TARGETID'] < 838860800000000
+    if tp[:3] == 'LRG' or tp[:3] == 'LGE':
+        print('applying extra cut for LRGs')
+        # Custom DELTACHI2 vs z cut from Rongpu
+        wz = ff['ZWARN'] == 0
+        wz &= ff['ZWARN']*0 == 0
+        wz &= ff['ZWARN'] != 999999
+        if ismock:
+            wz &= ff['Z']<1.5
+        else:
+            if dchi2 is not None:
+                from LSS import ssr_tools
+                selg = ssr_tools.LRG_goodz(ff)
+                wz &= selg
+    if tp[:3] == 'BGS':
+        wz = ff['ZWARN'] == 0
+        wz &= ff['ZWARN']*0 == 0
+        wz &= ff['ZWARN'] != 999999
+        if dchi2 is not None:
+            wz &= ff['DELTACHI2'] > dchi2
+    ff = ff[wz] # apply the "good z" cut to get the same objects as in the clustering catalog
+    del wz
+    weights_comp = 1./ff['FRACZ_TILELOCID'] if weightileloc else 129/(1+128*ff['PROB_OBS']) # compute WEIGHT_COMP in accordance with the mkclusdat function
+    weight_ntl = np.bincount(ff['NTILE']-1, weights=weights_comp) / np.bincount(ff['NTILE']-1) # mean of WEIGHT_COMP for each (positive integer) NTILE in the data. Note that the NTILE values are shifted down by 1 to avoid guaranteed division by zero for NTILE=0
+    comp_ntl = 1 / weight_ntl # the completeness is the inverse of the mean weight (for each NTILE). Indexed by NTILE-1
+    if args.compmd != 'altmtl':
+        fttl = np.bincount(ff['NTILE']-1, weights=ff['FRAC_TLOBS_TILES']) / np.bincount(ff['NTILE']-1) # mean of FRAC_TLOBS_TILES for each (positive integer) NTILE in data (although shouldn't this be computed in randoms?). Note that the NTILE values are shifted down by 1 to avoid guaranteed division by zero for NTILE=0
+        comp_ntl *= fttl # if not using altmtl, also multiply by the mean FRAC_TLOBS_TILES for each NTILE to get the completeness. Both are indexed by NTILE-1
+    return comp_ntl, weight_ntl # both are indexed by NTILE-1 as common.addnbar expects
  
 if args.nz == 'y':
     for reg in regions:#allreg:
@@ -368,10 +428,11 @@ if args.nz == 'y':
         extra_dir = 'nonKP'
         if args.compmd == 'altmtl':
             extra_dir = 'PIP'
-        clus_orig = dirin+'/'+extra_dir+'/'+args.input_tracer+'_'+reg+'_clustering.dat.fits'
-        comp_ntl, weight_ntl = None,None
-        if args.compmd == 'altmtl': #use original uncut data to get info, so that angular upweighting can be weighted consistently
+        clus_orig = dirin+'/'+extra_dir+'/'+args.input_tracer+'_'+reg+'_clustering.dat.fits' # use original uncut data to get info for consistency / so that angular upweighting can be weighted consistently (for altmtl/PIP)
+        if os.path.isfile(clus_orig): # use clustering catalog if it exists (then the process is simpler)
             comp_ntl, weight_ntl = get_ntile_info(clus_orig)
+        else: # if the clustering catalog does not exist, use the full catalog to get the NTILE info (particularly for DR3 BGS)
+            comp_ntl, weight_ntl = get_ntile_info_from_full(dirin+args.input_tracer+'_full'+args.use_map_veto+'.dat.fits', tp=args.input_tracer, reg=reg)
         common.addnbar(fb,bs=dz,zmin=zmin,zmax=zmax,P0=P0,nran=nran,par=args.par,compmd=nzcompmd,comp_ntl=comp_ntl,weight_ntl=weight_ntl,logger=logger)
 
 # determine linear weights for imaging systematics

--- a/scripts/mkCat_subsamp.py
+++ b/scripts/mkCat_subsamp.py
@@ -180,12 +180,12 @@ if args.mkfulldat == 'y':
             fsf_cols.append('ABSMAG01_SDSS_Z')
             umz_str = csplit[3]
             umz_split = float(csplit[4]) #value to split on
-            common.printlog('splitting on U-Z percentile '+str(umz_split),logger)
+            common.printlog('splitting on U-Z ' + 'percentile ' * ('per' in umz_str) + str(umz_split), logger)
         if 'SFR' in args.ccut:
             fsf_cols.append('SFR')
             sfr_str = csplit[3]
             sfr_split = float(csplit[4]) #value to split on
-            common.printlog('splitting on SFR percentile '+str(sfr_split),logger)
+            common.printlog('splitting on SFR ' + 'percentile ' * ('per' in sfr_str) + str(sfr_split), logger)
         common.printlog('about to get columns from fastspecfit '+str(fsf_cols),logger)
         fulldat = get_FSF_loa(fulldat,fsf_cols)
         ecorr = np.zeros(len(fulldat))
@@ -193,15 +193,19 @@ if args.mkfulldat == 'y':
             ecorr = -0.8*(fulldat['Z_not4clus']-0.1) #seemed best here for getting constant n(z) /global/cfs/cdirs/desi/survey/catalogs/DA2/analysis/loa-v1/LSScats/BGS_explore.ipynb
         sel = fulldat['ABSMAG01_SDSS_'+bnd] < abmag + ecorr
         common.printlog('length after Absmag selection '+str(np.sum(sel)),logger)
-        if 'SFR' in args.ccut and 'per' in args.ccut: #'per' for percentile
-            sel_sfr = fulldat['SFR'] > np.percentile(fulldat[sel]['SFR'],sfr_split)
+        if 'SFR' in args.ccut: # perform SFR cut
+            if 'per' in sfr_str: # 'per' for percentile; otherwise, use the value directly
+                sfr_split = np.percentile(fulldat[sel]['SFR'], sfr_split)
+            sel_sfr = fulldat['SFR'] > sfr_split
             if 'g' in sfr_str: #'g' for greater than
                 sel &= sel_sfr
             else:
                 sel &= ~sel_sfr
             common.printlog('length after SFR selection '+str(np.sum(sel)),logger)
-        if 'umz' in args.ccut and 'per' in args.ccut: #'per' for percentile
-            sel_umz = (fulldat['ABSMAG01_SDSS_U']-fulldat['ABSMAG01_SDSS_Z']) > np.percentile((fulldat[sel]['ABSMAG01_SDSS_U']-fulldat[sel]['ABSMAG01_SDSS_Z']),umz_split)
+        if 'umz' in args.ccut: # perform U-Z color cut
+            if 'per' in umz_str: # 'per' for percentile; otherwise, use the value directly
+                umz_split = np.percentile((fulldat[sel]['ABSMAG01_SDSS_U']-fulldat[sel]['ABSMAG01_SDSS_Z']), umz_split)
+            sel_umz = (fulldat['ABSMAG01_SDSS_U']-fulldat['ABSMAG01_SDSS_Z']) > umz_split
             if 'g' in umz_str: #'g' for greater than
                 sel &= sel_umz
             else:

--- a/scripts/mkCat_subsamp.py
+++ b/scripts/mkCat_subsamp.py
@@ -484,11 +484,15 @@ if args.imsys_clus == 'y':
     ranl = []
     for i in range(0,args.nran4imsys):
         ran = fitsio.read(os.path.join(dirout, tracer_out+'_NGC_'+str(i)+'_clustering.ran.fits'))
-        ran = rfn.drop_fields(ran, 'WEIGHT_IMLIN_CLUS', asrecarray=True) # drop the column if it exists - it breaks the concatenation of the randoms if some have it and some don't
         ranl.append(ran)
         ran = fitsio.read(os.path.join(dirout, tracer_out+'_SGC_'+str(i)+'_clustering.ran.fits'))
-        ran = rfn.drop_fields(ran, 'WEIGHT_IMLIN_CLUS', asrecarray=True) # drop the column if it exists - it breaks the concatenation of the randoms if some have it and some don't
         ranl.append(ran)
+    # check that randoms all have the same columns, otherwise the concatenation will fail
+    colnames = [set(rfn.get_names_flat(r.dtype)) for r in ranl]
+    common_colnames = set.intersection(*colnames)
+    for i, (ran, ran_colnames) in enumerate(zip(ranl, colnames)):
+        if ran_colnames != common_colnames:
+            ranl[i] = rfn.rec_drop_fields(ran, list(ran_colnames - common_colnames)) # drop any extra columns that are not in the common set of column names, so that all randoms have the same columns for concatenation
     rands = np.concatenate(ranl)
     
     #fiducial column name for weights, initialize as 1.

--- a/scripts/mkCat_subsamp.py
+++ b/scripts/mkCat_subsamp.py
@@ -487,16 +487,17 @@ if args.imsys_clus == 'y':
         ranl.append(ran)
         ran = fitsio.read(os.path.join(dirout, tracer_out+'_SGC_'+str(i)+'_clustering.ran.fits'))
         ranl.append(ran)
-    # check that randoms all have the same columns, otherwise the concatenation will fail
-    colnames = [set(rfn.get_names_flat(r.dtype)) for r in ranl]
-    common_colnames = set.intersection(*colnames)
-    for i, (ran, ran_colnames) in enumerate(zip(ranl, colnames)):
-        if ran_colnames != common_colnames:
-            ranl[i] = rfn.rec_drop_fields(ran, list(ran_colnames - common_colnames)) # drop any extra columns that are not in the common set of column names, so that all randoms have the same columns for concatenation
+    # fiducial column name for weights
+    syscol = 'WEIGHT_IMLIN_CLUS' 
+    # ensure that randoms either all have this column or all don't, otherwise the concatenation will fail. the mix may result from previously performed imaging systematics added to randoms with some randoms having been processed and some not
+    ran_has_syscol = [syscol in rfn.get_names_flat(ran.dtype) for ran in ranl]
+    if not all(ran_has_syscol):
+        for i in range(len(ranl)):
+            if ran_has_syscol[i]:
+                ranl[i] = rfn.rec_drop_fields(ranl[i], [syscol]) # drop the column from any randoms that have it, so that all randoms should have the same columns for concatenation
     rands = np.concatenate(ranl)
     
-    #fiducial column name for weights, initialize as 1.
-    syscol = 'WEIGHT_IMLIN_CLUS' 
+    # initialize the fiducial column name for weights as 1
     dat[syscol] = np.ones(len(dat))
     #photometric regions
     regl = ['S','N']

--- a/scripts/mkCat_subsamp.py
+++ b/scripts/mkCat_subsamp.py
@@ -141,7 +141,7 @@ def get_FSF_loa(indata,fsf_cols,fsf_dir='/dvs_ro/cfs/cdirs/desi/vac/dr2/fastspec
     #works with the data model that is new as of loa
     fsl = []
     for hp in range(0,12):
-        fsi = fitsio.read(fsf_dir+'fastspec-loa-main-bright-nside1-hp'+str(hp).zfill(2)+'.fits',ext='SPECPHOT',columns = fsf_cols)
+        fsi = fitsio.read(fsf_dir+'fastspec-loa-main-'+prog+'-nside1-hp'+str(hp).zfill(2)+'.fits', ext='SPECPHOT', columns=fsf_cols)
         fsl.append(fsi)
     fs = np.concatenate(fsl)
     del fsl


### PR DESCRIPTION
This should allow retrieving the ntile info (properly) without needing an uncut clustering catalog (which Ashley decided to avoid making for DA3 for BGS_ANY/BRIGHT/FAINT) as part of the subsample-making script. The procedure is mostly as we discussed with Ashley, although so far I have decided to make it more backwards compatible (e.g., if the uncut clustering catalog exists, the script would just read the ntile info from it as before https://github.com/desihub/LSS/commit/c1eb962cf0852225ab367f9ca361f9286facc4f4, and I applied the region split to the full catalog to keep things consistent), at the risk of being somewhat overcomplicated.

I still need to at least check that the script works for the non-trivial case (DR3 BGS). Then the change can be propagated to the BGS BRIGHT+FAINT combination script (where it should be simpler because it doesn't need to account for other tracers).